### PR TITLE
Refactor log package with builder pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
-cmd/fl/fl
 fl
 .task
 vendor/

--- a/cmd/fl/main.go
+++ b/cmd/fl/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/alecthomas/kong"
 	"github.com/funlessdev/funless-cli/pkg/client"
@@ -41,9 +42,11 @@ func main() {
 	cli := CLI{}
 	ctx := context.Background()
 
-	logger, err := log.NewBaseLogger(false)
+	logger, err := buildLogger()
+
 	if err != nil {
 		fmt.Println(err.Error())
+		return
 	}
 
 	flConfig := client.Config{Host: "http://localhost:8080"}
@@ -73,4 +76,10 @@ func main() {
 	)
 
 	kong_ctx.FatalIfErrorf(kong_ctx.Run())
+}
+
+func buildLogger() (log.FLogger, error) {
+	b := log.NewLoggerBuilder()
+	logger, err := b.WithDebug(true).SpinnerFrequency(150 * time.Millisecond).SpinnerCharSet(59).Build()
+	return logger, err
 }

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ go 1.18
 require (
 	github.com/alecthomas/kong v0.5.0
 	github.com/docker/docker v20.10.16+incompatible
+	github.com/docker/go-connections v0.4.0
 	github.com/theckman/yacspin v0.13.12
 )
 
@@ -29,7 +30,6 @@ require (
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/distribution v2.8.1+incompatible // indirect
-	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect

--- a/pkg/docker/preflight_test.go
+++ b/pkg/docker/preflight_test.go
@@ -33,7 +33,7 @@ func (sh *fakeShell) runShellCmd(cmd string, args ...string) (string, error) {
 }
 
 func Test_ensureDockerVersion(t *testing.T) {
-	l, _ := log.NewBaseLogger(false)
+	l, _ := log.NewLoggerBuilder().Build()
 	p := preflightChecksPipeline{shell: &fakeShell{out: "19.03.5", err: nil}, logger: l}
 	p.step(ensureDockerVersion)
 	assert.NoError(t, p.err)

--- a/pkg/log/builder.go
+++ b/pkg/log/builder.go
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
 package log
 
 import (

--- a/pkg/log/builder.go
+++ b/pkg/log/builder.go
@@ -1,0 +1,79 @@
+package log
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/theckman/yacspin"
+)
+
+type loggerBuilder struct {
+	debug   bool
+	spinCfg yacspin.Config
+	err     error
+}
+
+func NewLoggerBuilder() builder {
+	return &loggerBuilder{
+		spinCfg: yacspin.Config{
+			SuffixAutoColon:   true,
+			StopCharacter:     "✓",
+			StopColors:        []string{"fgGreen"},
+			StopFailCharacter: "✗",
+			StopFailColors:    []string{"fgRed"},
+		},
+	}
+}
+
+func (l *loggerBuilder) WithDebug(b bool) builder {
+	l.debug = b
+	return l
+}
+
+func (l *loggerBuilder) SpinnerFrequency(freq time.Duration) builder {
+
+	if freq <= time.Duration(0) {
+		l.err = fmt.Errorf("spinner frequency must be greater than 0, %w", l.err)
+		return l
+	}
+
+	if l.err != nil {
+		return l
+	}
+
+	l.spinCfg.Frequency = freq
+	return l
+}
+
+// // SpinnerCharSet sets the character set to use for the spinner animation [0 to 90].
+func (l *loggerBuilder) SpinnerCharSet(charset int) builder {
+	if charset < 0 || charset > 90 {
+		l.err = fmt.Errorf("spinner character set must be between 0 and 90, %w", l.err)
+		return l
+	}
+	if l.err != nil {
+		return l
+	}
+	l.spinCfg.CharSet = yacspin.CharSets[charset]
+	return l
+}
+
+// // Build returns a new logger instance.
+func (l *loggerBuilder) Build() (FLogger, error) {
+
+	if l.err != nil {
+		return nil, l.err
+	}
+
+	s, err := yacspin.New(l.spinCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	logger := &FLoggerImpl{
+		debug:          l.debug,
+		currentMessage: "",
+		spinner:        s,
+	}
+	return logger, nil
+}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -18,65 +18,32 @@ package log
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/theckman/yacspin"
 )
 
-type FLogger interface {
-	SpinnerSuffix(string)
-	SpinnerMessage(string)
-	StartSpinner(string)
-	StopSpinner(error) error
-
-	Info(args ...interface{})
-	Infof(format string, args ...interface{})
-
-	Debug(args ...interface{})
-	Debugf(format string, args ...interface{})
-}
-
-type BaseFLogger struct {
+type FLoggerImpl struct {
 	debug          bool
 	currentMessage string
 	spinner        *yacspin.Spinner
 }
 
-func NewBaseLogger(debug bool) (*BaseFLogger, error) {
-	cfg := yacspin.Config{
-		Frequency:         150 * time.Millisecond,
-		Colors:            []string{"fgYellow"},
-		CharSet:           yacspin.CharSets[59],
-		SuffixAutoColon:   true,
-		StopCharacter:     "✓",
-		StopColors:        []string{"fgGreen"},
-		StopFailCharacter: "✗",
-		StopFailColors:    []string{"fgRed"},
-	}
-
-	s, err := yacspin.New(cfg)
-	if err != nil {
-		return nil, err
-	}
-	return &BaseFLogger{debug: debug, spinner: s}, nil
-}
-
-func (l *BaseFLogger) SpinnerSuffix(suffix string) {
+func (l *FLoggerImpl) SpinnerSuffix(suffix string) {
 	l.spinner.Suffix(suffix)
 }
 
-func (l *BaseFLogger) SpinnerMessage(msg string) {
+func (l *FLoggerImpl) SpinnerMessage(msg string) {
 	l.currentMessage = msg
 	l.spinner.Message(msg)
 }
 
-func (l *BaseFLogger) StartSpinner(msg string) {
+func (l *FLoggerImpl) StartSpinner(msg string) {
 	l.currentMessage = msg
 	l.spinner.Message(msg)
 	_ = l.spinner.Start()
 }
 
-func (l *BaseFLogger) StopSpinner(err error) error {
+func (l *FLoggerImpl) StopSpinner(err error) error {
 	if err == nil {
 		l.spinner.StopMessage(l.currentMessage)
 		err = l.spinner.Stop()
@@ -87,22 +54,22 @@ func (l *BaseFLogger) StopSpinner(err error) error {
 	return err
 }
 
-func (l *BaseFLogger) Info(args ...interface{}) {
+func (l *FLoggerImpl) Info(args ...interface{}) {
 	fmt.Println(args...)
 }
 
-func (l *BaseFLogger) Infof(format string, args ...interface{}) {
+func (l *FLoggerImpl) Infof(format string, args ...interface{}) {
 	fmt.Printf(format, args...)
 }
 
-func (l *BaseFLogger) Debug(args ...interface{}) {
+func (l *FLoggerImpl) Debug(args ...interface{}) {
 	if l.debug {
 		fmt.Print("DEBUG: ")
 		fmt.Println(args...)
 	}
 }
 
-func (l *BaseFLogger) Debugf(format string, args ...interface{}) {
+func (l *FLoggerImpl) Debugf(format string, args ...interface{}) {
 	if l.debug {
 		fmt.Print("DEBUG: ")
 		fmt.Printf(format, args...)

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
 package log
 
 import (

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -1,0 +1,61 @@
+package log
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuilder(t *testing.T) {
+
+	t.Run("NewLoggerBuilder returns new builder", func(t *testing.T) {
+		builder := NewLoggerBuilder()
+		assert.NotNil(t, builder)
+	})
+
+	t.Run("NewLoggerBuilder returns builder with default values", func(t *testing.T) {
+		builder := NewLoggerBuilder()
+		assert.False(t, builder.(*loggerBuilder).debug)
+		assert.True(t, builder.(*loggerBuilder).spinCfg.SuffixAutoColon)
+		assert.Equal(t, "✓", builder.(*loggerBuilder).spinCfg.StopCharacter)
+		assert.Equal(t, []string{"fgGreen"}, builder.(*loggerBuilder).spinCfg.StopColors)
+		assert.Equal(t, "✗", builder.(*loggerBuilder).spinCfg.StopFailCharacter)
+		assert.Equal(t, []string{"fgRed"}, builder.(*loggerBuilder).spinCfg.StopFailColors)
+	})
+
+	t.Run("Build returns new logger", func(t *testing.T) {
+		logger, err := NewLoggerBuilder().Build()
+		assert.NoError(t, err)
+		assert.NotNil(t, logger)
+		assert.False(t, logger.(*FLoggerImpl).debug)
+	})
+
+	t.Run("WithDebug true activates the debug in logger", func(t *testing.T) {
+		logger, err := NewLoggerBuilder().WithDebug(true).Build()
+		assert.NoError(t, err)
+		assert.NotNil(t, logger)
+		assert.True(t, logger.(*FLoggerImpl).debug)
+	})
+
+	t.Run("SpinnerFrequency generates error if input is less or equal to 0", func(t *testing.T) {
+		logger, err := NewLoggerBuilder().SpinnerFrequency(0 * time.Millisecond).Build()
+		assert.Error(t, err)
+		assert.Nil(t, logger)
+	})
+
+	t.Run("SpinnerFrequency appends err if err is found", func(t *testing.T) {
+		builder := NewLoggerBuilder()
+		builder.(*loggerBuilder).err = errors.New("test err")
+		_, err := builder.SpinnerFrequency(0 * time.Millisecond).Build()
+		assert.Error(t, err)
+		assert.Equal(t, "spinner frequency must be greater than 0, test err", err.Error())
+	})
+
+	t.Run("SpinnerCharSet fails if input is out of range [0,90]", func(t *testing.T) {
+		logger, err := NewLoggerBuilder().SpinnerCharSet(91).Build()
+		assert.Error(t, err)
+		assert.Nil(t, logger)
+	})
+}

--- a/pkg/log/types.go
+++ b/pkg/log/types.go
@@ -1,0 +1,25 @@
+package log
+
+import "time"
+
+type (
+	FLogger interface {
+		SpinnerSuffix(string)
+		SpinnerMessage(string)
+		StartSpinner(string)
+		StopSpinner(error) error
+
+		Info(args ...interface{})
+		Infof(format string, args ...interface{})
+
+		Debug(args ...interface{})
+		Debugf(format string, args ...interface{})
+	}
+
+	builder interface {
+		WithDebug(bool) builder
+		SpinnerFrequency(time.Duration) builder
+		SpinnerCharSet(int) builder
+		Build() (FLogger, error)
+	}
+)

--- a/pkg/log/types.go
+++ b/pkg/log/types.go
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
 package log
 
 import "time"


### PR DESCRIPTION
This PR closes #17 

It polishes the logger code implementing the builder pattern so it is easy to do some logger customization.