### PR TITLE
use latest tag for docker images

### DIFF
--- a/pkg/command/constants.go
+++ b/pkg/command/constants.go
@@ -6,7 +6,7 @@
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,9 +14,8 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package command
 
-const FLCore = "ghcr.io/funlessdev/fl-core:0.3.2"
+const FLCore = "ghcr.io/funlessdev/fl-core:latest"
 
-const FLWorker = "ghcr.io/funlessdev/fl-worker:0.2.0"
+const FLWorker = "ghcr.io/funlessdev/fl-worker:latest"


### PR DESCRIPTION
This PR closes #18 

it changes the tag for the core and worker images to the `latest` tag.