### PR TITLE
Reset command to remove local deployment

### DIFF
--- a/pkg/admin/docker_utils.go
+++ b/pkg/admin/docker_utils.go
@@ -140,3 +140,35 @@ func getDockerHost() string {
 	}
 	return dockerHost
 }
+
+func flContainerExists(ctx context.Context, c *client.Client, containerName string) (bool, types.Container, error) {
+	containers, err := c.ContainerList(ctx, types.ContainerListOptions{
+		Filters: filters.NewArgs(filters.KeyValuePair{Key: "name", Value: containerName}),
+	})
+	if err != nil {
+		return false, types.Container{}, err
+	}
+
+	if len(containers) == 0 {
+		return false, types.Container{}, nil
+	}
+
+	return true, containers[0], nil
+}
+
+func functionContainersList(ctx context.Context, c *client.Client) ([]types.Container, error) {
+
+	// match all containers name containing funless suffix
+	filter := filters.NewArgs(filters.KeyValuePair{Key: "name", Value: "funless"})
+	filter.Contains("funless")
+
+	containers, err := c.ContainerList(ctx, types.ContainerListOptions{
+		Filters: filter,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return containers, nil
+}

--- a/pkg/admin/reset_local.go
+++ b/pkg/admin/reset_local.go
@@ -1,0 +1,72 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package admin
+
+import (
+	"context"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+)
+
+func RemoveFLNetwork(ctx context.Context, client *client.Client, flNetName string) error {
+	exists, net, err := flNetExists(ctx, client, flNetName)
+
+	if err != nil {
+		return err
+	}
+	if exists {
+		return client.NetworkRemove(ctx, net.ID)
+	}
+	return nil
+}
+
+func RemoveFLContainer(ctx context.Context, client *client.Client, name string) error {
+	exists, container, err := flContainerExists(ctx, client, name)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+
+	timeout := time.Duration(5 * time.Second)
+	if err := client.ContainerStop(ctx, container.ID, &timeout); err != nil {
+		return err
+	}
+
+	return client.ContainerRemove(ctx, container.ID, types.ContainerRemoveOptions{})
+}
+
+func RemoveFunctionContainers(ctx context.Context, client *client.Client) error {
+	containers, err := functionContainersList(ctx, client)
+	if err != nil {
+		return err
+	}
+	for _, container := range containers {
+		timeout := time.Duration(2 * time.Second)
+		if err := client.ContainerStop(ctx, container.ID, &timeout); err != nil {
+			return err
+		}
+		if err := client.ContainerRemove(ctx, container.ID, types.ContainerRemoveOptions{}); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}

--- a/pkg/command/admin.go
+++ b/pkg/command/admin.go
@@ -75,3 +75,36 @@ func (d *deploy) Run(ctx context.Context, logger log.FLogger) error {
 
 	return err
 }
+
+func (r *reset) Run(ctx context.Context, logger log.FLogger) error {
+	logger.Info("Removing local funless deployment...\n")
+
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.41"))
+	if err != nil {
+		return err
+	}
+
+	logger.StartSpinner("Removing Core container... ☠️")
+	if err := logger.StopSpinner(admin.RemoveFLContainer(ctx, cli, "fl-core")); err != nil {
+		return err
+	}
+
+	logger.StartSpinner("Removing Worker container... 🔪")
+	if err := logger.StopSpinner(admin.RemoveFLContainer(ctx, cli, "fl-worker")); err != nil {
+		return err
+	}
+
+	logger.StartSpinner("Removing the function containers... 🔫")
+	if err := logger.StopSpinner(admin.RemoveFunctionContainers(ctx, cli)); err != nil {
+		return err
+	}
+
+	logger.StartSpinner("Removing fl_net network... ✂️")
+	if err := logger.StopSpinner(admin.RemoveFLNetwork(ctx, cli, "fl_net")); err != nil {
+		return err
+	}
+
+	logger.Info("\nAll clear! 👍")
+
+	return err
+}


### PR DESCRIPTION
This PR adds the `fl admin reset` cmd to remove 

- core container (using the name `fl-core`),
- worker container (with `fl-worker` name)
- all eventual function containers (using `funless` suffix)
- the `fl_net` network.

