### PR TITLE
Manual dispatch and new build release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,47 +15,49 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: fl-release
+name: Release
 
 on:
   push:
     tags:
       - 'v*.*.*'
+    branches-ignore:
+      - '*'
+  workflow_dispatch:
 
 jobs:
   build:
-    name: Build
+    name: Publish Release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: License
-        uses: apache/skywalking-eyes@main
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: '>=1.18.0'
-      - name: Test
-        run: go test -v -cover ./...
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
   releases-matrix:
     name: Release fl binary
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # build and publish in parallel: linux/386, linux/amd64, linux/arm64, windows/386, windows/amd64, darwin/amd64, darwin/arm64
+        # build and publish in parallel: linux/amd64, linux/arm64, windows/amd64, darwin/amd64, darwin/arm64
         goos: [linux, windows, darwin]
-        goarch: ["386", amd64, arm64]
+        goarch: [amd64, arm64]
         exclude:
-          - goarch: "386"
-            goos: darwin
           - goarch: arm64
             goos: windows
     steps:
     - uses: actions/checkout@v3
-    - uses: wangyoucao577/go-release-action@v1.26
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        goos: ${{ matrix.goos }}
-        goarch: ${{ matrix.goarch }}
-        binary_name: "f"
-        extra_files: LICENSE README.md
+    - name: Release Go Binaries 
+        uses: wangyoucao577/go-release-action@v1.28
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          goos: ${{ matrix.goos }}
+          goarch: ${{ matrix.goarch }}
+          project_path: "."
+          build_command: |
+            if test -z "$TAG"
+            then TAG="$(git describe --tags --abbrev=0 2>/dev/null || git rev-parse --short HEAD)"
+            fi
+            echo "Building $TAG"
+            go build -ldflags "-X main.CLIVersion=$TAG" "$@"
+
+          binary_name: "fl"
+          extra_files: LICENSE README.md


### PR DESCRIPTION
This PR polishes the release CI. It removes some OS release combination (the 386 arch and windows arm) and updates the build command.

it also adds the workflow dispatch key to trigger release manually.