### PR TITLE
New command stubs

### DIFF
--- a/cmd/fl/main.go
+++ b/cmd/fl/main.go
@@ -34,7 +34,7 @@ var FLVersion = "vX.Y.Z.build"
 
 type CLI struct {
 	Fn    fn.Fn       `cmd:"" help:"todo fn subcommand help"`
-	Admin admin.Admin `cmd:"" help:"todo admin subcommand help"`
+	Admin admin.Admin `cmd:"" aliases:"a" help:"todo admin subcommand help"`
 
 	Version kong.VersionFlag `short:"v" cmd:"" passthrough:"" help:"show fl version"`
 }

--- a/cmd/fl/main.go
+++ b/cmd/fl/main.go
@@ -23,7 +23,8 @@ import (
 	"time"
 
 	"github.com/alecthomas/kong"
-	"github.com/funlessdev/fl-cli/internal/command"
+	"github.com/funlessdev/fl-cli/internal/command/admin"
+	"github.com/funlessdev/fl-cli/internal/command/fn"
 	"github.com/funlessdev/fl-cli/pkg/client"
 	"github.com/funlessdev/fl-cli/pkg/log"
 )
@@ -32,8 +33,8 @@ import (
 var FLVersion = "vX.Y.Z.build"
 
 type CLI struct {
-	Fn    command.Fn    `cmd:"" help:"todo fn subcommand help"`
-	Admin command.Admin `cmd:"" help:"todo admin subcommand help"`
+	Fn    fn.Fn       `cmd:"" help:"todo fn subcommand help"`
+	Admin admin.Admin `cmd:"" help:"todo admin subcommand help"`
 
 	Version kong.VersionFlag `short:"v" cmd:"" passthrough:"" help:"show fl version"`
 }

--- a/internal/command/admin/admin.go
+++ b/internal/command/admin/admin.go
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-package command
+package admin
 
 import (
 	"context"

--- a/internal/command/admin/admin.go
+++ b/internal/command/admin/admin.go
@@ -16,95 +16,12 @@
 // under the License.
 package admin
 
-import (
-	"context"
-	"fmt"
+type Admin struct {
+	Dev dev `cmd:"" help:"deploy locally with 1 core and 1 worker docker containers"`
 
-	"github.com/docker/docker/client"
-	"github.com/funlessdev/fl-cli/pkg"
-	"github.com/funlessdev/fl-cli/pkg/admin"
-	"github.com/funlessdev/fl-cli/pkg/log"
-)
+	Init  coreInit `cmd:"" help:"todo init subcommand help"`
+	Join  join     `cmd:"" help:"todo join subcommand help"`
+	Token token    `cmd:"" help:"todo token subcommand help"`
 
-type (
-	Admin struct {
-		Deploy deploy `cmd:"" help:"deploy 1 core and 1 worker locally with docker containers"`
-		Reset  reset  `cmd:"" help:"removes the deployment of local containers"`
-	}
-
-	deploy struct{}
-	reset  struct{}
-)
-
-func (d *deploy) Run(ctx context.Context, logger log.FLogger) error {
-	logger.Info("Deploying funless locally...\n")
-
-	logger.StartSpinner("Setting things up...")
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.41"))
-	if err != nil {
-		return err
-	}
-	deployer := admin.NewLocalDeployer(ctx, cli, "fl_net")
-
-	if err := logger.StopSpinner(deployer.Apply(admin.SetupFLNetwork)); err != nil {
-		return err
-	}
-
-	logger.StartSpinner(fmt.Sprintf("pulling Core image (%s) 📦", pkg.FLCore))
-	if err := logger.StopSpinner(deployer.Apply(admin.PullCoreImage)); err != nil {
-		return err
-	}
-
-	logger.StartSpinner(fmt.Sprintf("pulling Worker image (%s) 🗃", pkg.FLWorker))
-	if err := logger.StopSpinner(deployer.Apply(admin.PullWorkerImage)); err != nil {
-		return err
-	}
-
-	logger.StartSpinner("starting Core container 🎛️")
-	if err := logger.StopSpinner(deployer.Apply(admin.StartCoreContainer)); err != nil {
-		return err
-	}
-
-	logger.StartSpinner("starting Worker container 👷")
-	if err := logger.StopSpinner(deployer.Apply(admin.StartWorkerContainer)); err != nil {
-		return err
-	}
-
-	logger.Info("\nDeployment complete!")
-	logger.Info("You can now start using Funless! 🎉")
-
-	return err
-}
-
-func (r *reset) Run(ctx context.Context, logger log.FLogger) error {
-	logger.Info("Removing local funless deployment...\n")
-
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.41"))
-	if err != nil {
-		return err
-	}
-
-	logger.StartSpinner("Removing Core container... ☠️")
-	if err := logger.StopSpinner(admin.RemoveFLContainer(ctx, cli, "fl-core")); err != nil {
-		return err
-	}
-
-	logger.StartSpinner("Removing Worker container... 🔪")
-	if err := logger.StopSpinner(admin.RemoveFLContainer(ctx, cli, "fl-worker")); err != nil {
-		return err
-	}
-
-	logger.StartSpinner("Removing the function containers... 🔫")
-	if err := logger.StopSpinner(admin.RemoveFunctionContainers(ctx, cli)); err != nil {
-		return err
-	}
-
-	logger.StartSpinner("Removing fl_net network... ✂️")
-	if err := logger.StopSpinner(admin.RemoveFLNetwork(ctx, cli, "fl_net")); err != nil {
-		return err
-	}
-
-	logger.Info("\nAll clear! 👍")
-
-	return err
+	Reset reset `cmd:"" help:"removes the deployment of local containers"`
 }

--- a/internal/command/admin/dev.go
+++ b/internal/command/admin/dev.go
@@ -1,0 +1,53 @@
+package admin
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/docker/client"
+	"github.com/funlessdev/fl-cli/pkg"
+	"github.com/funlessdev/fl-cli/pkg/admin"
+	"github.com/funlessdev/fl-cli/pkg/log"
+)
+
+type dev struct{}
+
+func (d *dev) Run(ctx context.Context, logger log.FLogger) error {
+	logger.Info("Deploying funless locally...\n")
+
+	logger.StartSpinner("Setting things up...")
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.41"))
+	if err != nil {
+		return err
+	}
+	deployer := admin.NewLocalDeployer(ctx, cli, "fl_net")
+
+	if err := logger.StopSpinner(deployer.Apply(admin.SetupFLNetwork)); err != nil {
+		return err
+	}
+
+	logger.StartSpinner(fmt.Sprintf("pulling Core image (%s) 📦", pkg.FLCore))
+	if err := logger.StopSpinner(deployer.Apply(admin.PullCoreImage)); err != nil {
+		return err
+	}
+
+	logger.StartSpinner(fmt.Sprintf("pulling Worker image (%s) 🗃", pkg.FLWorker))
+	if err := logger.StopSpinner(deployer.Apply(admin.PullWorkerImage)); err != nil {
+		return err
+	}
+
+	logger.StartSpinner("starting Core container 🎛️")
+	if err := logger.StopSpinner(deployer.Apply(admin.StartCoreContainer)); err != nil {
+		return err
+	}
+
+	logger.StartSpinner("starting Worker container 👷")
+	if err := logger.StopSpinner(deployer.Apply(admin.StartWorkerContainer)); err != nil {
+		return err
+	}
+
+	logger.Info("\nDeployment complete!")
+	logger.Info("You can now start using Funless! 🎉")
+
+	return err
+}

--- a/internal/command/admin/dev.go
+++ b/internal/command/admin/dev.go
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package admin
 
 import (

--- a/internal/command/admin/init.go
+++ b/internal/command/admin/init.go
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package admin
 
 import (

--- a/internal/command/admin/init.go
+++ b/internal/command/admin/init.go
@@ -1,0 +1,14 @@
+package admin
+
+import (
+	"context"
+
+	"github.com/funlessdev/fl-cli/pkg/log"
+)
+
+type coreInit struct{} // init is reserved in Go
+
+func (d *coreInit) Run(ctx context.Context, logger log.FLogger) error {
+	logger.Info("admin init stub")
+	return nil
+}

--- a/internal/command/admin/join.go
+++ b/internal/command/admin/join.go
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package admin
 
 import (

--- a/internal/command/admin/join.go
+++ b/internal/command/admin/join.go
@@ -1,0 +1,14 @@
+package admin
+
+import (
+	"context"
+
+	"github.com/funlessdev/fl-cli/pkg/log"
+)
+
+type join struct{}
+
+func (d *join) Run(ctx context.Context, logger log.FLogger) error {
+	logger.Info("admin join stub")
+	return nil
+}

--- a/internal/command/admin/reset.go
+++ b/internal/command/admin/reset.go
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package admin
 
 import (

--- a/internal/command/admin/reset.go
+++ b/internal/command/admin/reset.go
@@ -1,0 +1,44 @@
+package admin
+
+import (
+	"context"
+
+	"github.com/docker/docker/client"
+	"github.com/funlessdev/fl-cli/pkg/admin"
+	"github.com/funlessdev/fl-cli/pkg/log"
+)
+
+type reset struct{}
+
+func (r *reset) Run(ctx context.Context, logger log.FLogger) error {
+	logger.Info("Removing local funless deployment...\n")
+
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.41"))
+	if err != nil {
+		return err
+	}
+
+	logger.StartSpinner("Removing Core container... ☠️")
+	if err := logger.StopSpinner(admin.RemoveFLContainer(ctx, cli, "fl-core")); err != nil {
+		return err
+	}
+
+	logger.StartSpinner("Removing Worker container... 🔪")
+	if err := logger.StopSpinner(admin.RemoveFLContainer(ctx, cli, "fl-worker")); err != nil {
+		return err
+	}
+
+	logger.StartSpinner("Removing the function containers... 🔫")
+	if err := logger.StopSpinner(admin.RemoveFunctionContainers(ctx, cli)); err != nil {
+		return err
+	}
+
+	logger.StartSpinner("Removing fl_net network... ✂️")
+	if err := logger.StopSpinner(admin.RemoveFLNetwork(ctx, cli, "fl_net")); err != nil {
+		return err
+	}
+
+	logger.Info("\nAll clear! 👍")
+
+	return err
+}

--- a/internal/command/admin/token.go
+++ b/internal/command/admin/token.go
@@ -1,0 +1,14 @@
+package admin
+
+import (
+	"context"
+
+	"github.com/funlessdev/fl-cli/pkg/log"
+)
+
+type token struct{}
+
+func (d *token) Run(ctx context.Context, logger log.FLogger) error {
+	logger.Info("admin token stub")
+	return nil
+}

--- a/internal/command/admin/token.go
+++ b/internal/command/admin/token.go
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package admin
 
 import (

--- a/internal/command/fn/fn.go
+++ b/internal/command/fn/fn.go
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-package command
+package fn
 
 import (
 	"context"

--- a/internal/command/fn/fn_test.go
+++ b/internal/command/fn/fn_test.go
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-package command
+package fn
 
 import (
 	"bytes"


### PR DESCRIPTION
This PR organizes the commands in their own folders and breaks the admin sub commands in different files.
It adds stubs for the new `init`, `join` and `token` commands. Lastly adds an alias for admin so it can be used with `fl a.`