### PR TITLE
Separate worker+core and worker+runtime networks in dev deployment

### DIFF
--- a/internal/command/admin/dev.go
+++ b/internal/command/admin/dev.go
@@ -37,7 +37,7 @@ func (d *dev) Run(ctx context.Context, logger log.FLogger) error {
 	if err != nil {
 		return err
 	}
-	deployer := admin.NewLocalDeployer(ctx, cli, "fl_net")
+	deployer := admin.NewLocalDeployer(ctx, cli, "fl_net", "fl_runtime_net")
 
 	if err := logger.StopSpinner(deployer.Apply(admin.SetupFLNetwork)); err != nil {
 		return err

--- a/internal/command/admin/dev.go
+++ b/internal/command/admin/dev.go
@@ -39,7 +39,7 @@ func (d *dev) Run(ctx context.Context, logger log.FLogger) error {
 	}
 	deployer := admin.NewLocalDeployer(ctx, cli, "fl_net", "fl_runtime_net")
 
-	if err := logger.StopSpinner(deployer.Apply(admin.SetupFLNetwork)); err != nil {
+	if err := logger.StopSpinner(deployer.Apply(admin.SetupFLNetworks)); err != nil {
 		return err
 	}
 

--- a/internal/command/admin/reset.go
+++ b/internal/command/admin/reset.go
@@ -55,6 +55,11 @@ func (r *reset) Run(ctx context.Context, logger log.FLogger) error {
 		return err
 	}
 
+	logger.StartSpinner("Removing fl_runtime_net network... ✂️")
+	if err := logger.StopSpinner(admin.RemoveFLNetwork(ctx, cli, "fl_runtime_net")); err != nil {
+		return err
+	}
+
 	logger.Info("\nAll clear! 👍")
 
 	return err

--- a/pkg/admin/deploy_local.go
+++ b/pkg/admin/deploy_local.go
@@ -28,17 +28,20 @@ import (
 )
 
 type LocalDeployer struct {
-	ctx       context.Context
-	client    *client.Client
-	flNetId   string
-	flNetName string
+	ctx              context.Context
+	client           *client.Client
+	flNetId          string
+	flRuntimeNetId   string
+	flNetName        string
+	flRuntimeNetName string
 }
 
-func NewLocalDeployer(ctx context.Context, client *client.Client, flNetName string) *LocalDeployer {
+func NewLocalDeployer(ctx context.Context, client *client.Client, flNetName string, flRuntimeNetName string) *LocalDeployer {
 	return &LocalDeployer{
-		ctx:       ctx,
-		client:    client,
-		flNetName: flNetName,
+		ctx:              ctx,
+		client:           client,
+		flNetName:        flNetName,
+		flRuntimeNetName: flRuntimeNetName,
 	}
 }
 
@@ -54,8 +57,8 @@ func (d *LocalDeployer) Apply(f func(*LocalDeployer) error) error {
 }
 
 func SetupFLNetwork(d *LocalDeployer) error {
+	// Network for Core + Worker
 	exists, net, err := flNetExists(d.ctx, d.client, d.flNetName)
-
 	if err != nil {
 		return err
 	}
@@ -64,8 +67,25 @@ func SetupFLNetwork(d *LocalDeployer) error {
 		d.flNetId = net.ID
 		return nil
 	}
-	id, err := flNetCreate(d.ctx, d.client, d.flNetName)
+	id, err := flNetCreate(d.ctx, d.client, d.flNetName, false)
+	if err != nil {
+		return err
+	}
 	d.flNetId = id
+
+	// Network for Worker + Runtimes
+	exists, net, err = flNetExists(d.ctx, d.client, d.flRuntimeNetName)
+	if err != nil {
+		return err
+	}
+	if exists {
+
+		d.flRuntimeNetId = net.ID
+		return nil
+	}
+	runtimeId, err := flNetCreate(d.ctx, d.client, d.flRuntimeNetName, true)
+	d.flRuntimeNetId = runtimeId
+
 	return err
 }
 
@@ -104,7 +124,7 @@ func StartCoreContainer(d *LocalDeployer) error {
 		networking: &netConf,
 	}
 
-	return startContainer(d.ctx, d.client, configs, "fl-core")
+	return startCoreContainer(d.ctx, d.client, configs, "fl-core")
 }
 
 func StartWorkerContainer(d *LocalDeployer) error {
@@ -133,5 +153,5 @@ func StartWorkerContainer(d *LocalDeployer) error {
 		host:       hostConf,
 		networking: &netConf,
 	}
-	return startContainer(d.ctx, d.client, configs, "fl-worker")
+	return startWorkerContainer(d.ctx, d.client, configs, "fl-worker", d.flRuntimeNetId)
 }

--- a/pkg/admin/deploy_local.go
+++ b/pkg/admin/deploy_local.go
@@ -56,7 +56,7 @@ func (d *LocalDeployer) Apply(f func(*LocalDeployer) error) error {
 	return nil
 }
 
-func SetupFLNetwork(d *LocalDeployer) error {
+func SetupFLNetworks(d *LocalDeployer) error {
 	// Network for Core + Worker
 	exists, net, err := flNetExists(d.ctx, d.client, d.flNetName)
 	if err != nil {


### PR DESCRIPTION
This PR adds a separate internal network for worker-runtime communication, leaving worker and core in a different network, when deploying a development environment.

This might solve some network errors in local deployments.