### PR TITLE
Add host logs folder mounted in the local deploy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 )
 
 require (
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/stretchr/testify v1.7.1
 )

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 h1:dcztxKSvZ4Id8iPpHERQBbIJfabdt4wUm5qy3wOL2Zc=
 github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6/go.mod h1:E2VnQOmVuvZB6UYnnDB0qG5Nq/1tD9acaOpo6xmt0Kw=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=

--- a/internal/command/admin/dev.go
+++ b/internal/command/admin/dev.go
@@ -32,11 +32,12 @@ func (d *dev) Run(ctx context.Context, deployer deploy.DockerDeployer, logger lo
 	logger.Info("Deploying funless locally...\n")
 
 	_ = logger.StartSpinner("Setting things up...")
-	if err := deployer.SetupClient(ctx); err != nil {
+
+	if err := deployer.Setup(ctx); err != nil {
 		return logger.StopSpinner(err)
 	}
 
-	if err := logger.StopSpinner(deployer.SetupFLNetworks(ctx)); err != nil {
+	if err := logger.StopSpinner(deployer.CreateFLNetworks(ctx)); err != nil {
 		return err
 	}
 

--- a/internal/command/admin/dev_test.go
+++ b/internal/command/admin/dev_test.go
@@ -38,7 +38,7 @@ func TestRun(t *testing.T) {
 	deployer := mocks.NewDockerDeployer(t)
 
 	t.Run("print error when setup client fails", func(t *testing.T) {
-		deployer.On("SetupClient", ctx).Return(func(ctx context.Context) error {
+		deployer.On("Setup", ctx).Return(func(ctx context.Context) error {
 			return errors.New("error")
 		}).Once()
 
@@ -56,10 +56,10 @@ func TestRun(t *testing.T) {
 	})
 
 	t.Run("print error when docker networks setup fails", func(t *testing.T) {
-		deployer.On("SetupClient", ctx).Return(func(ctx context.Context) error {
+		deployer.On("Setup", ctx).Return(func(ctx context.Context) error {
 			return nil
 		})
-		deployer.On("SetupFLNetworks", ctx).Return(func(ctx context.Context) error {
+		deployer.On("CreateFLNetworks", ctx).Return(func(ctx context.Context) error {
 			return errors.New("error")
 		}).Once()
 
@@ -77,7 +77,7 @@ func TestRun(t *testing.T) {
 	})
 
 	t.Run("print error when pulling core image fails", func(t *testing.T) {
-		deployer.On("SetupFLNetworks", ctx).Return(func(ctx context.Context) error {
+		deployer.On("CreateFLNetworks", ctx).Return(func(ctx context.Context) error {
 			return nil
 		})
 		deployer.On("PullCoreImage", ctx).Return(func(ctx context.Context) error {

--- a/internal/command/admin/reset.go
+++ b/internal/command/admin/reset.go
@@ -29,7 +29,7 @@ type reset struct{}
 func (r *reset) Run(ctx context.Context, deployer deploy.DockerDeployer, logger log.FLogger) error {
 	logger.Info("Removing local funless deployment...\n")
 
-	if err := deployer.SetupClient(ctx); err != nil {
+	if err := deployer.Setup(ctx); err != nil {
 		return err
 	}
 

--- a/internal/command/admin/reset_test.go
+++ b/internal/command/admin/reset_test.go
@@ -37,7 +37,7 @@ func TestResetRun(t *testing.T) {
 	deployer := mocks.NewDockerDeployer(t)
 
 	t.Run("print error when setup client fails", func(t *testing.T) {
-		deployer.On("SetupClient", ctx).Return(func(ctx context.Context) error {
+		deployer.On("Setup", ctx).Return(func(ctx context.Context) error {
 			return errors.New("error")
 		}).Once()
 
@@ -53,7 +53,7 @@ func TestResetRun(t *testing.T) {
 	})
 
 	t.Run("print error when docker networks setup fails", func(t *testing.T) {
-		deployer.On("SetupClient", ctx).Return(func(ctx context.Context) error {
+		deployer.On("Setup", ctx).Return(func(ctx context.Context) error {
 			return nil
 		})
 		deployer.On("RemoveCoreContainer", ctx).Return(func(ctx context.Context) error {

--- a/pkg/deploy/types.go
+++ b/pkg/deploy/types.go
@@ -20,9 +20,9 @@ package deploy
 import "context"
 
 type DockerDeployer interface {
-	SetupClient(ctx context.Context) error
+	Setup(ctx context.Context) error
 
-	SetupFLNetworks(ctx context.Context) error
+	CreateFLNetworks(ctx context.Context) error
 	PullCoreImage(ctx context.Context) error
 	PullWorkerImage(ctx context.Context) error
 	StartCore(ctx context.Context) error

--- a/test/integration/dev_test.go
+++ b/test/integration/dev_test.go
@@ -71,8 +71,8 @@ func TestAdminDevRun(t *testing.T) {
 		_ = localDeployer.RemoveFLNetworks(ctx)
 	})
 
-	t.Run("should successfully deploy without creating networks if they already exist", func(t *testing.T) {
-		_ = localDeployer.SetupFLNetworks(ctx)
+	t.Run("should successfully deploy without creating networks when they already exist", func(t *testing.T) {
+		_ = localDeployer.CreateFLNetworks(ctx)
 
 		err := admCmd.Dev.Run(ctx, localDeployer, logger)
 
@@ -92,8 +92,8 @@ func TestAdminDevRun(t *testing.T) {
 		_ = localDeployer.RemoveFLNetworks(ctx)
 	})
 
-	t.Run("should fail if core is already running", func(t *testing.T) {
-		_ = localDeployer.SetupFLNetworks(ctx)
+	t.Run("should fail when core is already running", func(t *testing.T) {
+		_ = localDeployer.CreateFLNetworks(ctx)
 		_ = localDeployer.PullCoreImage(ctx)
 		_ = localDeployer.StartCore(ctx)
 
@@ -103,6 +103,27 @@ func TestAdminDevRun(t *testing.T) {
 
 		_ = localDeployer.RemoveCoreContainer(ctx)
 		_ = localDeployer.RemoveFLNetworks(ctx)
+	})
+
+	t.Run("should create ~/funless-logs folder when successfully deployed", func(t *testing.T) {
+		err := admCmd.Dev.Run(ctx, localDeployer, logger)
+
+		assert.NoError(t, err)
+
+		info, err := os.Stat("~/funless-logs")
+		assert.NoError(t, err)
+		assert.True(t, info.IsDir())
+
+		files, err := os.ReadDir("~/funless-logs")
+		assert.NoError(t, err)
+		assert.GreaterOrEqual(t, len(files), 1)
+
+		_ = localDeployer.RemoveCoreContainer(ctx)
+		_ = localDeployer.RemoveWorkerContainer(ctx)
+		_ = localDeployer.RemoveFLNetworks(ctx)
+
+		err = os.RemoveAll("~/funless-logs")
+		assert.NoError(t, err)
 	})
 }
 

--- a/test/mocks/DockerDeployer.go
+++ b/test/mocks/DockerDeployer.go
@@ -30,6 +30,20 @@ type DockerDeployer struct {
 	mock.Mock
 }
 
+// CreateFLNetworks provides a mock function with given fields: ctx
+func (_m *DockerDeployer) CreateFLNetworks(ctx context.Context) error {
+	ret := _m.Called(ctx)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // PullCoreImage provides a mock function with given fields: ctx
 func (_m *DockerDeployer) PullCoreImage(ctx context.Context) error {
 	ret := _m.Called(ctx)
@@ -114,22 +128,8 @@ func (_m *DockerDeployer) RemoveWorkerContainer(_a0 context.Context) error {
 	return r0
 }
 
-// SetupClient provides a mock function with given fields: ctx
-func (_m *DockerDeployer) SetupClient(ctx context.Context) error {
-	ret := _m.Called(ctx)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
-		r0 = rf(ctx)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// SetupFLNetworks provides a mock function with given fields: ctx
-func (_m *DockerDeployer) SetupFLNetworks(ctx context.Context) error {
+// Setup provides a mock function with given fields: ctx
+func (_m *DockerDeployer) Setup(ctx context.Context) error {
 	ret := _m.Called(ctx)
 
 	var r0 error


### PR DESCRIPTION
This PR closes #27 

It uses the go-homedir pkg to retrieve the user home directory and then creates (if not present) ~/funless-logs folder.
The folder is mounted in the core and worker containers to add the log files on the host machine for easy access.