### PR TITLE
Custom deployment images

### DIFF
--- a/cmd/fl/main.go
+++ b/cmd/fl/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/funlessdev/fl-cli/internal/command/admin"
 	"github.com/funlessdev/fl-cli/internal/command/fn"
+	"github.com/funlessdev/fl-cli/pkg"
 	"github.com/funlessdev/fl-cli/pkg/client"
 	"github.com/funlessdev/fl-cli/pkg/deploy"
 	"github.com/funlessdev/fl-cli/pkg/log"
@@ -73,7 +74,9 @@ func main() {
 		kong.BindTo(logger, (*log.FLogger)(nil)),
 		kong.BindTo(localDeployer, (*deploy.DockerDeployer)(nil)),
 		kong.Vars{
-			"version": FLVersion,
+			"version":              FLVersion,
+			"default_core_image":   pkg.FLCore,
+			"default_worker_image": pkg.FLWorker,
 		},
 		kong.UsageOnError(),
 	)

--- a/internal/command/admin/dev.go
+++ b/internal/command/admin/dev.go
@@ -18,14 +18,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/funlessdev/fl-cli/pkg"
 	"github.com/funlessdev/fl-cli/pkg/deploy"
 	"github.com/funlessdev/fl-cli/pkg/log"
 )
 
 type dev struct {
-	CoreImage   string `name:"core" short:"c" help:"core docker image to deploy"`
-	WorkerImage string `name:"worker" short:"w" help:"worker docker image to deploy"`
+	CoreImage   string `name:"core" short:"c" help:"core docker image to deploy" default:"${default_core_image}"`
+	WorkerImage string `name:"worker" short:"w" help:"worker docker image to deploy" default:"${default_worker_image}"`
 }
 
 func (d *dev) Run(ctx context.Context, deployer deploy.DockerDeployer, logger log.FLogger) error {
@@ -33,15 +32,7 @@ func (d *dev) Run(ctx context.Context, deployer deploy.DockerDeployer, logger lo
 
 	_ = logger.StartSpinner("Setting things up...")
 
-	if d.CoreImage == "" {
-		d.CoreImage = pkg.FLCore
-	}
-
-	if d.WorkerImage == "" {
-		d.WorkerImage = pkg.FLWorker
-	}
-
-	if err := deployer.Setup(ctx); err != nil {
+	if err := deployer.Setup(ctx, d.CoreImage, d.WorkerImage); err != nil {
 		return logger.StopSpinner(err)
 	}
 
@@ -50,22 +41,22 @@ func (d *dev) Run(ctx context.Context, deployer deploy.DockerDeployer, logger lo
 	}
 
 	_ = logger.StartSpinner(fmt.Sprintf("pulling Core image (%s) 📦", d.CoreImage))
-	if err := logger.StopSpinner(deployer.PullCoreImage(ctx, d.CoreImage)); err != nil {
+	if err := logger.StopSpinner(deployer.PullCoreImage(ctx)); err != nil {
 		return err
 	}
 
 	_ = logger.StartSpinner(fmt.Sprintf("pulling Worker image (%s) 🗃", d.WorkerImage))
-	if err := logger.StopSpinner(deployer.PullWorkerImage(ctx, d.WorkerImage)); err != nil {
+	if err := logger.StopSpinner(deployer.PullWorkerImage(ctx)); err != nil {
 		return err
 	}
 
 	_ = logger.StartSpinner("starting Core container 🎛️")
-	if err := logger.StopSpinner(deployer.StartCore(ctx, d.CoreImage)); err != nil {
+	if err := logger.StopSpinner(deployer.StartCore(ctx)); err != nil {
 		return err
 	}
 
 	_ = logger.StartSpinner("starting Worker container 👷")
-	if err := logger.StopSpinner(deployer.StartWorker(ctx, d.WorkerImage)); err != nil {
+	if err := logger.StopSpinner(deployer.StartWorker(ctx)); err != nil {
 		return err
 	}
 

--- a/internal/command/admin/dev.go
+++ b/internal/command/admin/dev.go
@@ -23,12 +23,23 @@ import (
 	"github.com/funlessdev/fl-cli/pkg/log"
 )
 
-type dev struct{}
+type dev struct {
+	CoreImage   string `name:"core" short:"c" help:"core docker image to deploy"`
+	WorkerImage string `name:"worker" short:"w" help:"worker docker image to deploy"`
+}
 
 func (d *dev) Run(ctx context.Context, deployer deploy.DockerDeployer, logger log.FLogger) error {
 	logger.Info("Deploying funless locally...\n")
 
 	_ = logger.StartSpinner("Setting things up...")
+
+	if d.CoreImage == "" {
+		d.CoreImage = pkg.FLCore
+	}
+
+	if d.WorkerImage == "" {
+		d.WorkerImage = pkg.FLWorker
+	}
 
 	if err := deployer.Setup(ctx); err != nil {
 		return logger.StopSpinner(err)
@@ -38,23 +49,23 @@ func (d *dev) Run(ctx context.Context, deployer deploy.DockerDeployer, logger lo
 		return err
 	}
 
-	_ = logger.StartSpinner(fmt.Sprintf("pulling Core image (%s) 📦", pkg.FLCore))
-	if err := logger.StopSpinner(deployer.PullCoreImage(ctx)); err != nil {
+	_ = logger.StartSpinner(fmt.Sprintf("pulling Core image (%s) 📦", d.CoreImage))
+	if err := logger.StopSpinner(deployer.PullCoreImage(ctx, d.CoreImage)); err != nil {
 		return err
 	}
 
-	_ = logger.StartSpinner(fmt.Sprintf("pulling Worker image (%s) 🗃", pkg.FLWorker))
-	if err := logger.StopSpinner(deployer.PullWorkerImage(ctx)); err != nil {
+	_ = logger.StartSpinner(fmt.Sprintf("pulling Worker image (%s) 🗃", d.WorkerImage))
+	if err := logger.StopSpinner(deployer.PullWorkerImage(ctx, d.WorkerImage)); err != nil {
 		return err
 	}
 
 	_ = logger.StartSpinner("starting Core container 🎛️")
-	if err := logger.StopSpinner(deployer.StartCore(ctx)); err != nil {
+	if err := logger.StopSpinner(deployer.StartCore(ctx, d.CoreImage)); err != nil {
 		return err
 	}
 
 	_ = logger.StartSpinner("starting Worker container 👷")
-	if err := logger.StopSpinner(deployer.StartWorker(ctx)); err != nil {
+	if err := logger.StopSpinner(deployer.StartWorker(ctx, d.WorkerImage)); err != nil {
 		return err
 	}
 

--- a/internal/command/admin/dev_test.go
+++ b/internal/command/admin/dev_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/funlessdev/fl-cli/pkg"
 	"github.com/funlessdev/fl-cli/pkg/log"
 	"github.com/funlessdev/fl-cli/test/mocks"
 	"github.com/stretchr/testify/assert"
@@ -77,7 +78,7 @@ func TestRun(t *testing.T) {
 		deployer.On("CreateFLNetworks", ctx).Return(func(ctx context.Context) error {
 			return nil
 		})
-		deployer.On("PullCoreImage", ctx).Return(func(ctx context.Context) error {
+		deployer.On("PullCoreImage", ctx, pkg.FLCore).Return(func(ctx context.Context, image string) error {
 			return errors.New("error")
 		}).Once()
 
@@ -97,10 +98,10 @@ func TestRun(t *testing.T) {
 	})
 
 	t.Run("print error when pulling worker image fails", func(t *testing.T) {
-		deployer.On("PullCoreImage", ctx).Return(func(ctx context.Context) error {
+		deployer.On("PullCoreImage", ctx, pkg.FLCore).Return(func(ctx context.Context, image string) error {
 			return nil
 		})
-		deployer.On("PullWorkerImage", ctx).Return(func(ctx context.Context) error {
+		deployer.On("PullWorkerImage", ctx, pkg.FLWorker).Return(func(ctx context.Context, image string) error {
 			return errors.New("error")
 		}).Once()
 
@@ -122,10 +123,10 @@ func TestRun(t *testing.T) {
 	})
 
 	t.Run("print error when starting core fails", func(t *testing.T) {
-		deployer.On("PullWorkerImage", ctx).Return(func(ctx context.Context) error {
+		deployer.On("PullWorkerImage", ctx, pkg.FLWorker).Return(func(ctx context.Context, image string) error {
 			return nil
 		})
-		deployer.On("StartCore", ctx).Return(func(ctx context.Context) error {
+		deployer.On("StartCore", ctx, pkg.FLCore).Return(func(ctx context.Context, image string) error {
 			return errors.New("error")
 		}).Once()
 
@@ -149,10 +150,10 @@ func TestRun(t *testing.T) {
 	})
 
 	t.Run("print error when starting worker fails", func(t *testing.T) {
-		deployer.On("StartCore", ctx).Return(func(ctx context.Context) error {
+		deployer.On("StartCore", ctx, pkg.FLCore).Return(func(ctx context.Context, image string) error {
 			return nil
 		})
-		deployer.On("StartWorker", ctx).Return(func(ctx context.Context) error {
+		deployer.On("StartWorker", ctx, pkg.FLWorker).Return(func(ctx context.Context, image string) error {
 			return errors.New("error")
 		}).Once()
 
@@ -178,7 +179,7 @@ func TestRun(t *testing.T) {
 	})
 
 	t.Run("successful prints when everything goes well", func(t *testing.T) {
-		deployer.On("StartWorker", ctx).Return(func(ctx context.Context) error {
+		deployer.On("StartWorker", ctx, pkg.FLWorker).Return(func(ctx context.Context, image string) error {
 			return nil
 		})
 

--- a/internal/command/admin/reset.go
+++ b/internal/command/admin/reset.go
@@ -26,7 +26,7 @@ type reset struct{}
 func (r *reset) Run(ctx context.Context, deployer deploy.DockerDeployer, logger log.FLogger) error {
 	logger.Info("Removing local funless deployment...\n")
 
-	if err := deployer.Setup(ctx); err != nil {
+	if err := deployer.Setup(ctx, "", ""); err != nil {
 		return err
 	}
 

--- a/internal/command/admin/reset_test.go
+++ b/internal/command/admin/reset_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/funlessdev/fl-cli/pkg/log"
 	"github.com/funlessdev/fl-cli/test/mocks"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestResetRun(t *testing.T) {
@@ -34,9 +35,10 @@ func TestResetRun(t *testing.T) {
 	deployer := mocks.NewDockerDeployer(t)
 
 	t.Run("print error when setup client fails", func(t *testing.T) {
-		deployer.On("Setup", ctx).Return(func(ctx context.Context) error {
-			return errors.New("error")
-		}).Once()
+		deployer.On("Setup", ctx, mock.AnythingOfType("string"), mock.AnythingOfType("string")).
+			Return(func(ctx context.Context, coreImg string, workerImg string) error {
+				return errors.New("error")
+			}).Once()
 
 		_ = reset.Run(ctx, deployer, testLogger)
 
@@ -50,9 +52,10 @@ func TestResetRun(t *testing.T) {
 	})
 
 	t.Run("print error when docker networks setup fails", func(t *testing.T) {
-		deployer.On("Setup", ctx).Return(func(ctx context.Context) error {
-			return nil
-		})
+		deployer.On("Setup", ctx, mock.AnythingOfType("string"), mock.AnythingOfType("string")).
+			Return(func(ctx context.Context, coreImg string, workerImg string) error {
+				return nil
+			})
 		deployer.On("RemoveCoreContainer", ctx).Return(func(ctx context.Context) error {
 			return errors.New("error")
 		}).Once()

--- a/pkg/deploy/docker_utils.go
+++ b/pkg/deploy/docker_utils.go
@@ -40,11 +40,11 @@ func imageExistsLocally(ctx context.Context, c *client.Client, image string) (bo
 	notFound := client.IsErrNotFound(err)
 
 	/* notFound being false means the error is something else; we still return false as we can't be sure the image actually exists */
-	if err != nil && notFound == false {
+	if err != nil && !notFound {
 		return false, err
 	}
 
-	if notFound == true {
+	if notFound {
 		return false, nil
 	}
 

--- a/pkg/deploy/docker_utils.go
+++ b/pkg/deploy/docker_utils.go
@@ -35,7 +35,31 @@ type configuration struct {
 	networking *network.NetworkingConfig
 }
 
+func imageExistsLocally(ctx context.Context, c *client.Client, image string) (bool, error) {
+	_, _, err := c.ImageInspectWithRaw(ctx, image)
+	notFound := client.IsErrNotFound(err)
+
+	/* notFound being false means the error is something else; we still return false as we can't be sure the image actually exists */
+	if err != nil && notFound == false {
+		return false, err
+	}
+
+	if notFound == true {
+		return false, nil
+	}
+
+	return true, nil
+}
+
 func pullFLImage(ctx context.Context, c *client.Client, image string) error {
+	exists, err := imageExistsLocally(ctx, c, image)
+	if exists {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
 	out, err := c.ImagePull(ctx, image, types.ImagePullOptions{})
 	if err != nil {
 		return err
@@ -122,6 +146,7 @@ func startWorkerContainer(ctx context.Context, c *client.Client, configs configu
 	}
 
 	if err := c.NetworkConnect(ctx, runtimeNetId, resp.ID, runtimeNetSettings); err != nil {
+		fmt.Println(err)
 		return err
 	}
 

--- a/pkg/deploy/local.go
+++ b/pkg/deploy/local.go
@@ -24,7 +24,6 @@ import (
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
-	"github.com/funlessdev/fl-cli/pkg"
 	"github.com/mitchellh/go-homedir"
 )
 
@@ -105,18 +104,18 @@ func (d *LocalDeployer) CreateFLNetworks(ctx context.Context) error {
 	return err
 }
 
-func (d *LocalDeployer) PullCoreImage(ctx context.Context) error {
-	return pullFLImage(ctx, d.client, pkg.FLCore)
+func (d *LocalDeployer) PullCoreImage(ctx context.Context, image string) error {
+	return pullFLImage(ctx, d.client, image)
 }
 
-func (d *LocalDeployer) PullWorkerImage(ctx context.Context) error {
-	return pullFLImage(ctx, d.client, pkg.FLWorker)
+func (d *LocalDeployer) PullWorkerImage(ctx context.Context, image string) error {
+	return pullFLImage(ctx, d.client, image)
 }
 
-func (d *LocalDeployer) StartCore(ctx context.Context) error {
+func (d *LocalDeployer) StartCore(ctx context.Context, image string) error {
 
 	containerConfig := &container.Config{
-		Image: pkg.FLCore,
+		Image: image,
 		ExposedPorts: nat.PortSet{
 			"4001/tcp": struct{}{},
 		},
@@ -152,12 +151,12 @@ func (d *LocalDeployer) StartCore(ctx context.Context) error {
 	return startCoreContainer(ctx, d.client, configs, d.coreContainerName)
 }
 
-func (d *LocalDeployer) StartWorker(ctx context.Context) error {
+func (d *LocalDeployer) StartWorker(ctx context.Context, image string) error {
 
 	dockerHost := getDockerHost()
 
 	containerConfig := &container.Config{
-		Image: pkg.FLWorker,
+		Image: image,
 		Env:   []string{"RUNTIME_NETWORK=" + d.flRuntimeNetName},
 	}
 

--- a/pkg/deploy/local.go
+++ b/pkg/deploy/local.go
@@ -37,7 +37,9 @@ type LocalDeployer struct {
 	flRuntimeNetId   string
 	flRuntimeNetName string
 
+	coreImg             string
 	coreContainerName   string
+	workerImg           string
 	workerContainerName string
 }
 
@@ -51,7 +53,10 @@ func NewLocalDeployer(coreContainerName, workerContainerName, flNetName, flRunti
 	}
 }
 
-func (d *LocalDeployer) Setup(ctx context.Context) error {
+func (d *LocalDeployer) Setup(ctx context.Context, coreImg, workerImg string) error {
+	d.coreImg = coreImg
+	d.workerImg = workerImg
+
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.41"))
 	if err != nil {
 		return err
@@ -104,18 +109,18 @@ func (d *LocalDeployer) CreateFLNetworks(ctx context.Context) error {
 	return err
 }
 
-func (d *LocalDeployer) PullCoreImage(ctx context.Context, image string) error {
-	return pullFLImage(ctx, d.client, image)
+func (d *LocalDeployer) PullCoreImage(ctx context.Context) error {
+	return pullFLImage(ctx, d.client, d.coreImg)
 }
 
-func (d *LocalDeployer) PullWorkerImage(ctx context.Context, image string) error {
-	return pullFLImage(ctx, d.client, image)
+func (d *LocalDeployer) PullWorkerImage(ctx context.Context) error {
+	return pullFLImage(ctx, d.client, d.workerImg)
 }
 
-func (d *LocalDeployer) StartCore(ctx context.Context, image string) error {
+func (d *LocalDeployer) StartCore(ctx context.Context) error {
 
 	containerConfig := &container.Config{
-		Image: image,
+		Image: d.coreImg,
 		ExposedPorts: nat.PortSet{
 			"4001/tcp": struct{}{},
 		},
@@ -151,12 +156,12 @@ func (d *LocalDeployer) StartCore(ctx context.Context, image string) error {
 	return startCoreContainer(ctx, d.client, configs, d.coreContainerName)
 }
 
-func (d *LocalDeployer) StartWorker(ctx context.Context, image string) error {
+func (d *LocalDeployer) StartWorker(ctx context.Context) error {
 
 	dockerHost := getDockerHost()
 
 	containerConfig := &container.Config{
-		Image: image,
+		Image: d.workerImg,
 		Env:   []string{"RUNTIME_NETWORK=" + d.flRuntimeNetName},
 	}
 

--- a/pkg/deploy/types.go
+++ b/pkg/deploy/types.go
@@ -20,10 +20,10 @@ type DockerDeployer interface {
 	Setup(ctx context.Context) error
 
 	CreateFLNetworks(ctx context.Context) error
-	PullCoreImage(ctx context.Context) error
-	PullWorkerImage(ctx context.Context) error
-	StartCore(ctx context.Context) error
-	StartWorker(ctx context.Context) error
+	PullCoreImage(ctx context.Context, image string) error
+	PullWorkerImage(ctx context.Context, image string) error
+	StartCore(ctx context.Context, image string) error
+	StartWorker(ctx context.Context, image string) error
 
 	RemoveFLNetworks(ctx context.Context) error
 	RemoveCoreContainer(context.Context) error

--- a/pkg/deploy/types.go
+++ b/pkg/deploy/types.go
@@ -17,13 +17,13 @@ package deploy
 import "context"
 
 type DockerDeployer interface {
-	Setup(ctx context.Context) error
+	Setup(ctx context.Context, coreImg, workerImg string) error
 
 	CreateFLNetworks(ctx context.Context) error
-	PullCoreImage(ctx context.Context, image string) error
-	PullWorkerImage(ctx context.Context, image string) error
-	StartCore(ctx context.Context, image string) error
-	StartWorker(ctx context.Context, image string) error
+	PullCoreImage(ctx context.Context) error
+	PullWorkerImage(ctx context.Context) error
+	StartCore(ctx context.Context) error
+	StartWorker(ctx context.Context) error
 
 	RemoveFLNetworks(ctx context.Context) error
 	RemoveCoreContainer(context.Context) error

--- a/test/integration/dev_test.go
+++ b/test/integration/dev_test.go
@@ -95,8 +95,8 @@ func TestAdminDevRun(t *testing.T) {
 
 	t.Run("should fail when core is already running", func(t *testing.T) {
 		_ = localDeployer.CreateFLNetworks(ctx)
-		_ = localDeployer.PullCoreImage(ctx, admCmd.Dev.CoreImage)
-		_ = localDeployer.StartCore(ctx, admCmd.Dev.CoreImage)
+		_ = localDeployer.PullCoreImage(ctx)
+		_ = localDeployer.StartCore(ctx)
 
 		err := admCmd.Dev.Run(ctx, localDeployer, logger)
 

--- a/test/integration/dev_test.go
+++ b/test/integration/dev_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
 	"github.com/funlessdev/fl-cli/internal/command/admin"
+	"github.com/funlessdev/fl-cli/pkg"
 	"github.com/funlessdev/fl-cli/pkg/deploy"
 	"github.com/funlessdev/fl-cli/pkg/log"
 	"github.com/mitchellh/go-homedir"
@@ -36,7 +37,9 @@ func TestAdminDevRun(t *testing.T) {
 		t.Skip("set INTEGRATION_TESTS (optionally with DOCKER_HOST) to run this test")
 	}
 
-	admCmd := admin.Admin{Dev: struct{}{}}
+	admCmd := admin.Admin{}
+	admCmd.Dev.CoreImage = pkg.FLCore
+	admCmd.Dev.WorkerImage = pkg.FLWorker
 
 	coreName := "fl-core-test"
 	workerName := "fl-worker-test"
@@ -92,8 +95,8 @@ func TestAdminDevRun(t *testing.T) {
 
 	t.Run("should fail when core is already running", func(t *testing.T) {
 		_ = localDeployer.CreateFLNetworks(ctx)
-		_ = localDeployer.PullCoreImage(ctx)
-		_ = localDeployer.StartCore(ctx)
+		_ = localDeployer.PullCoreImage(ctx, admCmd.Dev.CoreImage)
+		_ = localDeployer.StartCore(ctx, admCmd.Dev.CoreImage)
 
 		err := admCmd.Dev.Run(ctx, localDeployer, logger)
 

--- a/test/integration/reset_test.go
+++ b/test/integration/reset_test.go
@@ -35,7 +35,7 @@ func TestAdminResetRun(t *testing.T) {
 		t.Skip("set INTEGRATION_TESTS (optionally with DOCKER_HOST) to run this test")
 	}
 
-	admCmd := admin.Admin{Dev: struct{}{}, Reset: struct{}{}}
+	admCmd := admin.Admin{Reset: struct{}{}}
 
 	coreName := "fl-core-test"
 	workerName := "fl-worker-test"

--- a/test/integration/reset_test.go
+++ b/test/integration/reset_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
 	"github.com/funlessdev/fl-cli/internal/command/admin"
+	"github.com/funlessdev/fl-cli/pkg"
 	"github.com/funlessdev/fl-cli/pkg/deploy"
 	"github.com/funlessdev/fl-cli/pkg/log"
 	"github.com/stretchr/testify/assert"
@@ -36,6 +37,8 @@ func TestAdminResetRun(t *testing.T) {
 	}
 
 	admCmd := admin.Admin{Reset: struct{}{}}
+	admCmd.Dev.CoreImage = pkg.FLCore
+	admCmd.Dev.WorkerImage = pkg.FLWorker
 
 	coreName := "fl-core-test"
 	workerName := "fl-worker-test"

--- a/test/mocks/DockerDeployer.go
+++ b/test/mocks/DockerDeployer.go
@@ -41,13 +41,13 @@ func (_m *DockerDeployer) CreateFLNetworks(ctx context.Context) error {
 	return r0
 }
 
-// PullCoreImage provides a mock function with given fields: ctx
-func (_m *DockerDeployer) PullCoreImage(ctx context.Context) error {
-	ret := _m.Called(ctx)
+// PullCoreImage provides a mock function with given fields: ctx, image
+func (_m *DockerDeployer) PullCoreImage(ctx context.Context, image string) error {
+	ret := _m.Called(ctx, image)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
-		r0 = rf(ctx)
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, image)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -55,13 +55,13 @@ func (_m *DockerDeployer) PullCoreImage(ctx context.Context) error {
 	return r0
 }
 
-// PullWorkerImage provides a mock function with given fields: ctx
-func (_m *DockerDeployer) PullWorkerImage(ctx context.Context) error {
-	ret := _m.Called(ctx)
+// PullWorkerImage provides a mock function with given fields: ctx, image
+func (_m *DockerDeployer) PullWorkerImage(ctx context.Context, image string) error {
+	ret := _m.Called(ctx, image)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
-		r0 = rf(ctx)
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, image)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -139,13 +139,13 @@ func (_m *DockerDeployer) Setup(ctx context.Context) error {
 	return r0
 }
 
-// StartCore provides a mock function with given fields: ctx
-func (_m *DockerDeployer) StartCore(ctx context.Context) error {
-	ret := _m.Called(ctx)
+// StartCore provides a mock function with given fields: ctx, image
+func (_m *DockerDeployer) StartCore(ctx context.Context, image string) error {
+	ret := _m.Called(ctx, image)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
-		r0 = rf(ctx)
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, image)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -153,13 +153,13 @@ func (_m *DockerDeployer) StartCore(ctx context.Context) error {
 	return r0
 }
 
-// StartWorker provides a mock function with given fields: ctx
-func (_m *DockerDeployer) StartWorker(ctx context.Context) error {
-	ret := _m.Called(ctx)
+// StartWorker provides a mock function with given fields: ctx, image
+func (_m *DockerDeployer) StartWorker(ctx context.Context, image string) error {
+	ret := _m.Called(ctx, image)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
-		r0 = rf(ctx)
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, image)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/test/mocks/DockerDeployer.go
+++ b/test/mocks/DockerDeployer.go
@@ -41,13 +41,13 @@ func (_m *DockerDeployer) CreateFLNetworks(ctx context.Context) error {
 	return r0
 }
 
-// PullCoreImage provides a mock function with given fields: ctx, image
-func (_m *DockerDeployer) PullCoreImage(ctx context.Context, image string) error {
-	ret := _m.Called(ctx, image)
+// PullCoreImage provides a mock function with given fields: ctx
+func (_m *DockerDeployer) PullCoreImage(ctx context.Context) error {
+	ret := _m.Called(ctx)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
-		r0 = rf(ctx, image)
+	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -55,13 +55,13 @@ func (_m *DockerDeployer) PullCoreImage(ctx context.Context, image string) error
 	return r0
 }
 
-// PullWorkerImage provides a mock function with given fields: ctx, image
-func (_m *DockerDeployer) PullWorkerImage(ctx context.Context, image string) error {
-	ret := _m.Called(ctx, image)
+// PullWorkerImage provides a mock function with given fields: ctx
+func (_m *DockerDeployer) PullWorkerImage(ctx context.Context) error {
+	ret := _m.Called(ctx)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
-		r0 = rf(ctx, image)
+	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -125,8 +125,22 @@ func (_m *DockerDeployer) RemoveWorkerContainer(_a0 context.Context) error {
 	return r0
 }
 
-// Setup provides a mock function with given fields: ctx
-func (_m *DockerDeployer) Setup(ctx context.Context) error {
+// Setup provides a mock function with given fields: ctx, coreImg, workerImg
+func (_m *DockerDeployer) Setup(ctx context.Context, coreImg string, workerImg string) error {
+	ret := _m.Called(ctx, coreImg, workerImg)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, coreImg, workerImg)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// StartCore provides a mock function with given fields: ctx
+func (_m *DockerDeployer) StartCore(ctx context.Context) error {
 	ret := _m.Called(ctx)
 
 	var r0 error
@@ -139,27 +153,13 @@ func (_m *DockerDeployer) Setup(ctx context.Context) error {
 	return r0
 }
 
-// StartCore provides a mock function with given fields: ctx, image
-func (_m *DockerDeployer) StartCore(ctx context.Context, image string) error {
-	ret := _m.Called(ctx, image)
+// StartWorker provides a mock function with given fields: ctx
+func (_m *DockerDeployer) StartWorker(ctx context.Context) error {
+	ret := _m.Called(ctx)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
-		r0 = rf(ctx, image)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// StartWorker provides a mock function with given fields: ctx, image
-func (_m *DockerDeployer) StartWorker(ctx context.Context, image string) error {
-	ret := _m.Called(ctx, image)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
-		r0 = rf(ctx, image)
+	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
This PR adds the possibility to deploy using `fl admin dev` with custom Worker and Core images.

This closes #56.