### PR TITLE
Separate parse and run

### DIFF
--- a/cmd/fl/app/app.go
+++ b/cmd/fl/app/app.go
@@ -16,7 +16,6 @@ package app
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -37,7 +36,7 @@ type CLI struct {
 	Version kong.VersionFlag `short:"v" cmd:"" passthrough:"" help:"show fl version"`
 }
 
-func Run(version string) {
+func ParseCMD(version string) (*kong.Context, error) {
 	cli := CLI{}
 	ctx := context.Background()
 
@@ -47,15 +46,13 @@ func Run(version string) {
 	wasmBuilder := build.NewWasmBuilder()
 
 	if err != nil {
-		fmt.Println(err.Error())
-		return
+		return nil, err
 	}
 
 	flConfig := client.Config{Host: "http://localhost:4000"}
 	flClient, err := client.NewClient(http.DefaultClient, flConfig)
 	if err != nil {
-		fmt.Println(err.Error())
-		return
+		return nil, err
 	}
 	fnSvc := &client.FnService{Client: flClient}
 
@@ -80,8 +77,11 @@ func Run(version string) {
 		},
 		kong.UsageOnError(),
 	)
+	return kong_ctx, nil
+}
 
-	kong_ctx.FatalIfErrorf(kong_ctx.Run())
+func Run(kong_ctx *kong.Context) error {
+	return kong_ctx.Run()
 }
 
 func buildLogger() (log.FLogger, error) {

--- a/cmd/fl/main.go
+++ b/cmd/fl/main.go
@@ -14,11 +14,21 @@
 
 package main
 
-import "github.com/funlessdev/fl-cli/cmd/fl/app"
+import (
+	"fmt"
+	"os"
+
+	"github.com/funlessdev/fl-cli/cmd/fl/app"
+)
 
 // CLIVersion holds the current version, to be set by the build with go build -ldflags "-X main.FLVersion=<version>"
 var FLVersion = "vX.Y.Z.build"
 
 func main() {
-	app.Run(FLVersion)
+	if ctx, err := app.ParseCMD(FLVersion); err == nil {
+		ctx.FatalIfErrorf(app.Run(ctx))
+	} else {
+		fmt.Println("Error parsing command line arguments:", err.Error())
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
This PR refactors the app run into ParseCMD and Run, moving the FatalIfError into main.go