### PR TITLE
Remove unused Namespace field

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -34,9 +34,8 @@ type Client struct {
 }
 
 type Config struct {
-	Host      string
-	Namespace string
-	BaseURL   *url.URL
+	Host    string
+	BaseURL *url.URL
 }
 
 // NewClient creates a new funless client with the provided http client and configuration.


### PR DESCRIPTION
This PR closes #30 

There was a leftover Namespace field in the Config struct in client.go