### PR TITLE
Implement new command

### DIFF
--- a/internal/command/fn/new.go
+++ b/internal/command/fn/new.go
@@ -59,7 +59,9 @@ func (n *New) Run(ctx context.Context, logger log.FLogger) error {
 	}
 
 	// copy template to current directory with the name of the function
-	pkg.Copy(srcLanguageTemplate, destFunc)
+	if err := pkg.Copy(srcLanguageTemplate, destFunc); err != nil {
+		return err
+	}
 
 	logger.Infof("Function \"%s\" created!", n.Name)
 

--- a/internal/command/fn/new_test.go
+++ b/internal/command/fn/new_test.go
@@ -1,0 +1,118 @@
+// Copyright 2022 Giuseppe De Palma, Matteo Trentin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fn
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/funlessdev/fl-cli/pkg/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	ctx := context.TODO()
+
+	var out bytes.Buffer
+	testLogger, _ := log.NewLoggerBuilder().WithWriter(&out).DisableAnimation().Build()
+
+	t.Run("error when function name already exists", func(t *testing.T) {
+		testOutDir, err := os.MkdirTemp("", "funless-test-new-outdir-")
+		require.NoError(t, err)
+		defer os.RemoveAll(testOutDir)
+
+		// Create a folder with the same name of the function
+		err = os.MkdirAll(filepath.Join(testOutDir, "test"), 0755)
+		require.NoError(t, err)
+
+		newCmd := New{
+			Name:   "test",
+			OutDir: testOutDir,
+		}
+
+		err = newCmd.Run(ctx, testLogger)
+		require.Error(t, err)
+
+		require.Contains(t, err.Error(), "already exists")
+	})
+
+	t.Run("no error when template dir is not found", func(t *testing.T) {
+		out.Reset()
+
+		testOutDir, err := os.MkdirTemp("", "funless-test-new-outdir-")
+		require.NoError(t, err)
+		defer os.RemoveAll(testOutDir)
+
+		newCmd := New{
+			Name:        "test",
+			Language:    "js",
+			TemplateDir: filepath.Join(testOutDir, "not-exists"),
+			OutDir:      testOutDir,
+		}
+
+		err = newCmd.Run(ctx, testLogger)
+		require.NoError(t, err)
+
+		require.Contains(t, out.String(), "Pulling default templates!")
+	})
+
+	t.Run("error when template is not found", func(t *testing.T) {
+		out.Reset()
+
+		testOutDir, err := os.MkdirTemp("", "funless-test-new-outdir-")
+		require.NoError(t, err)
+		defer os.RemoveAll(testOutDir)
+
+		newCmd := New{
+			Name:        "test",
+			Language:    "not-exists",
+			TemplateDir: filepath.Join(testOutDir, "not-exists"),
+			OutDir:      testOutDir,
+		}
+
+		err = newCmd.Run(ctx, testLogger)
+		require.Error(t, err)
+
+		require.Contains(t, err.Error(), "no valid template for")
+	})
+
+	t.Run("creates a new function when no error", func(t *testing.T) {
+		out.Reset()
+
+		testOutDir, err := os.MkdirTemp("", "funless-test-new-outdir-")
+		require.NoError(t, err)
+		defer os.RemoveAll(testOutDir)
+
+		newCmd := New{
+			Name:        "test",
+			Language:    "js",
+			TemplateDir: filepath.Join(testOutDir, "not-exists"),
+			OutDir:      testOutDir,
+		}
+
+		err = newCmd.Run(ctx, testLogger)
+		require.NoError(t, err)
+
+		require.Contains(t, out.String(), "Pulling default templates!")
+		require.Contains(t, out.String(), "Function \"test\" created!")
+
+		// Check if the function folder is created
+		_, err = os.Stat(filepath.Join(testOutDir, "test"))
+		require.NoError(t, err)
+	})
+}

--- a/internal/command/template/template.go
+++ b/internal/command/template/template.go
@@ -16,4 +16,5 @@ package template
 
 type Template struct {
 	Pull Pull `cmd:"" help:"pull a template from a repository"`
+	List List `cmd:"" help:"list available templates"`
 }

--- a/internal/command/template/template_list.go
+++ b/internal/command/template/template_list.go
@@ -1,0 +1,47 @@
+package template
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/funlessdev/fl-cli/pkg/log"
+)
+
+type List struct {
+	TemplateDir string `short:"d" type:"path" default:"./template" help:"the directory to read the templates from"`
+}
+
+func (l *List) Run(ctx context.Context, logger log.FLogger) error {
+	tpath := filepath.Join(l.TemplateDir, "template")
+	var templates []string
+
+	templateFolders, err := os.ReadDir(tpath)
+	if os.IsNotExist(err) {
+		logger.Info("No templates found! You can use 'fl template pull' to download some templates.")
+		return nil
+	}
+
+	for _, file := range templateFolders {
+		if file.IsDir() {
+			templates = append(templates, file.Name())
+		}
+	}
+
+	logger.Infof("Available templates:\n%s\n", formatTemplateList(templates))
+
+	return nil
+}
+
+func formatTemplateList(availableTemplates []string) string {
+	var result string
+	sort.Slice(availableTemplates, func(i, j int) bool {
+		return availableTemplates[i] < availableTemplates[j]
+	})
+	for _, template := range availableTemplates {
+		result += fmt.Sprintf("- %s\n", template)
+	}
+	return result
+}

--- a/internal/command/template/template_list.go
+++ b/internal/command/template/template_list.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Giuseppe De Palma, Matteo Trentin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package template
 
 import (

--- a/internal/command/template/template_list.go
+++ b/internal/command/template/template_list.go
@@ -11,7 +11,7 @@ import (
 )
 
 type List struct {
-	TemplateDir string `short:"d" type:"path" default:"./template" help:"the directory to read the templates from"`
+	TemplateDir string `short:"d" type:"path" default:"." help:"the directory to read the templates from"`
 }
 
 func (l *List) Run(ctx context.Context, logger log.FLogger) error {

--- a/internal/command/template/template_list_test.go
+++ b/internal/command/template/template_list_test.go
@@ -58,7 +58,8 @@ func TestListTemplates(t *testing.T) {
 			OutDir:     tmpDir,
 		}
 
-		templatePullCmd.Run(ctx, testLogger)
+		err = templatePullCmd.Run(ctx, testLogger)
+		require.NoError(t, err)
 
 		listCmd := List{
 			TemplateDir: tmpDir,

--- a/internal/command/template/template_list_test.go
+++ b/internal/command/template/template_list_test.go
@@ -1,0 +1,59 @@
+package template
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/funlessdev/fl-cli/pkg"
+	"github.com/funlessdev/fl-cli/pkg/log"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	FoundTemplates = "Available templates:"
+	NoTemplates    = "No templates found! You can use 'fl template pull' to download some templates."
+)
+
+func TestListTemplates(t *testing.T) {
+	ctx := context.TODO()
+
+	t.Run("prints no templates found when no templates are available", func(t *testing.T) {
+		newCmd := List{}
+		var outbuf bytes.Buffer
+		testLogger, _ := log.NewLoggerBuilder().WithWriter(&outbuf).DisableAnimation().Build()
+
+		err := newCmd.Run(ctx, testLogger)
+		require.NoError(t, err)
+		t.Logf("out: %s", (&outbuf).String())
+
+		out := strings.Trim((&outbuf).String(), "\n")
+		require.Equal(t, NoTemplates, out)
+	})
+
+	t.Run("prints available templates", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "funless-test-")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir)
+
+		templatePullCmd := Pull{
+			Repository: pkg.DefaultTemplateRepository,
+			OutDir:     tmpDir,
+		}
+
+		var outbuf bytes.Buffer
+		testLogger, _ := log.NewLoggerBuilder().WithWriter(&outbuf).DisableAnimation().Build()
+		templatePullCmd.Run(ctx, testLogger)
+
+		newCmd := List{
+			TemplateDir: tmpDir,
+		}
+
+		err = newCmd.Run(ctx, testLogger)
+		require.NoError(t, err)
+
+		require.Contains(t, (&outbuf).String(), FoundTemplates)
+	})
+}

--- a/internal/command/template/template_list_test.go
+++ b/internal/command/template/template_list_test.go
@@ -19,21 +19,22 @@ const (
 
 func TestListTemplates(t *testing.T) {
 	ctx := context.TODO()
+	var outbuf bytes.Buffer
+	testLogger, _ := log.NewLoggerBuilder().WithWriter(&outbuf).DisableAnimation().Build()
 
 	t.Run("prints no templates found when no templates are available", func(t *testing.T) {
-		newCmd := List{}
-		var outbuf bytes.Buffer
-		testLogger, _ := log.NewLoggerBuilder().WithWriter(&outbuf).DisableAnimation().Build()
+		listCmd := List{}
 
-		err := newCmd.Run(ctx, testLogger)
+		err := listCmd.Run(ctx, testLogger)
 		require.NoError(t, err)
-		t.Logf("out: %s", (&outbuf).String())
 
-		out := strings.Trim((&outbuf).String(), "\n")
+		out := strings.Trim(outbuf.String(), "\n")
 		require.Equal(t, NoTemplates, out)
 	})
 
 	t.Run("prints available templates", func(t *testing.T) {
+		outbuf.Reset()
+
 		tmpDir, err := os.MkdirTemp("", "funless-test-")
 		require.NoError(t, err)
 		defer os.RemoveAll(tmpDir)
@@ -43,17 +44,15 @@ func TestListTemplates(t *testing.T) {
 			OutDir:     tmpDir,
 		}
 
-		var outbuf bytes.Buffer
-		testLogger, _ := log.NewLoggerBuilder().WithWriter(&outbuf).DisableAnimation().Build()
 		templatePullCmd.Run(ctx, testLogger)
 
-		newCmd := List{
+		listCmd := List{
 			TemplateDir: tmpDir,
 		}
 
-		err = newCmd.Run(ctx, testLogger)
+		err = listCmd.Run(ctx, testLogger)
 		require.NoError(t, err)
 
-		require.Contains(t, (&outbuf).String(), FoundTemplates)
+		require.Contains(t, outbuf.String(), FoundTemplates)
 	})
 }

--- a/internal/command/template/template_list_test.go
+++ b/internal/command/template/template_list_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Giuseppe De Palma, Matteo Trentin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package template
 
 import (

--- a/internal/command/template/template_pull.go
+++ b/internal/command/template/template_pull.go
@@ -82,7 +82,13 @@ func (p *Pull) Run(ctx context.Context, logger log.FLogger) error {
 	if len(copyOpts.notCopiedTemplates) > 0 {
 		logger.Infof("Skipped %d template(s) (already present): %v\n", len(copyOpts.notCopiedTemplates), copyOpts.notCopiedTemplates)
 	}
-	logger.Infof("Retrieved %d templates from %s : %v", len(copyOpts.copiedTemplates), p.Repository, copyOpts.copiedTemplates)
+
+	if len(copyOpts.copiedTemplates) == 0 {
+		logger.Info("No new templates retrieved.")
+	} else {
+		logger.Infof("Retrieved %d templates from %s : %v\n", len(copyOpts.copiedTemplates), p.Repository, copyOpts.copiedTemplates)
+	}
+
 	return nil
 }
 

--- a/internal/command/template/template_pull.go
+++ b/internal/command/template/template_pull.go
@@ -17,20 +17,18 @@ package template
 import (
 	"context"
 	"errors"
-	"fmt"
-	"io"
 	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
 
+	"github.com/funlessdev/fl-cli/pkg"
 	"github.com/funlessdev/fl-cli/pkg/log"
 	"github.com/go-git/go-git/v5"
 )
 
 type Pull struct {
 	Repository string `arg:"" default:"https://github.com/funlessdev/fl-templates.git" help:"the repository to pull the template folder from"`
-	OutDir     string `short:"o" default:"." help:"the output directory where the template folder will be placed"`
+	OutDir     string `short:"o" type:"existingdir" default:"." help:"the output directory where the template folder will be placed"`
 	Force      bool   `short:"f" default:"false" help:"overwrite the template if it already exists"`
 }
 
@@ -128,7 +126,9 @@ func copySingleTemplate(dir fs.DirEntry, c *copyOpts) {
 		c.copiedTemplates = append(c.copiedTemplates, language)
 
 		// Now actually copy the template
-		if err := copy(c.srcDir, c.destDir, language); err != nil {
+		src := filepath.Join(c.srcDir, language)
+		dest := filepath.Join(c.destDir, language)
+		if err := pkg.Copy(src, dest); err != nil {
 			c.err = err
 		}
 	} else {
@@ -144,87 +144,4 @@ func canCopyTemplate(destDir string, language string) bool {
 		return false
 	}
 	return true
-}
-
-func copy(srcDir string, destDir string, entry string) error {
-	src := filepath.Join(srcDir, entry)
-	dest := filepath.Join(destDir, entry)
-
-	// Get properties of source
-	info, err := os.Stat(src)
-	if err != nil {
-		return err
-	}
-
-	// If it's a directory, create it and copy recursively
-	if info.IsDir() {
-		// 1. Create the dest directory
-		if err := os.MkdirAll(dest, info.Mode()); err != nil {
-			return fmt.Errorf("error creating: %s - %s", dest, err.Error())
-		}
-
-		// 2. Read the source directory
-		entries, err := os.ReadDir(src)
-		if err != nil {
-			// If we fail to read the source directory, remove the created directory
-			os.RemoveAll(dest)
-			return err
-		}
-
-		// 3. For each entry in the directory, recursively copy it
-		for _, dirEntry := range entries {
-			if err := copy(src, dest, dirEntry.Name()); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-
-	// If it's a file, copy it
-	return copySingleFile(src, dest)
-}
-
-func copySingleFile(src, dest string) error {
-	info, err := os.Stat(src)
-	if err != nil {
-		return err
-	}
-
-	err = ensureBaseDir(dest)
-	if err != nil {
-		return fmt.Errorf("error creating base directory: %s", err.Error())
-	}
-
-	f, err := os.Create(dest)
-	if err != nil {
-		return fmt.Errorf("error creating dest file: %s", err.Error())
-	}
-	defer f.Close()
-
-	if err = os.Chmod(f.Name(), info.Mode()); err != nil {
-		return fmt.Errorf("error setting dest file mode: %s", err.Error())
-	}
-
-	s, err := os.Open(src)
-	if err != nil {
-		return fmt.Errorf("error opening src file: %s", err.Error())
-	}
-	defer s.Close()
-
-	_, err = io.Copy(f, s)
-	if err != nil {
-		return fmt.Errorf("Error copying dest file: %s\n" + err.Error())
-	}
-
-	return nil
-}
-
-// ensureBaseDir creates the base directory of a given file path, if it does not exist.
-func ensureBaseDir(fpath string) error {
-	baseDir := path.Dir(fpath)
-	info, err := os.Stat(baseDir)
-	if err == nil && info.IsDir() {
-		return nil
-	}
-	return os.MkdirAll(baseDir, 0755)
 }

--- a/internal/command/template/template_pull_test.go
+++ b/internal/command/template/template_pull_test.go
@@ -31,7 +31,7 @@ func TestTemplatePull(t *testing.T) {
 	testLogger, _ := log.NewLoggerBuilder().WithWriter(os.Stdout).DisableAnimation().Build()
 
 	t.Run("template pull", func(t *testing.T) {
-		testOutDir, err := os.MkdirTemp("", "funless-test-templates-outdir-")
+		testOutDir, err := os.MkdirTemp("", "funless-test-template-outdir-")
 		require.NoError(t, err)
 		defer os.RemoveAll(testOutDir)
 
@@ -50,7 +50,7 @@ func TestTemplatePull(t *testing.T) {
 	})
 
 	t.Run("template pull with force", func(t *testing.T) {
-		testOutDir, err := os.MkdirTemp("", "funless-test-templates-outdir-")
+		testOutDir, err := os.MkdirTemp("", "funless-test-template-outdir-")
 		require.NoError(t, err)
 		defer os.RemoveAll(testOutDir)
 

--- a/internal/command/template/template_pull_test.go
+++ b/internal/command/template/template_pull_test.go
@@ -17,7 +17,6 @@ package template
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -95,50 +94,4 @@ func TestTemplatePull(t *testing.T) {
 		err := templatePullCmd.Run(ctx, testLogger)
 		require.Error(t, err)
 	})
-}
-
-// Test for the copy function
-func Test_copy(t *testing.T) {
-	createSource := func(t *testing.T, numberOfFiles, mode int) (string, error) {
-		t.Helper()
-		data := []byte("a funless function")
-
-		// create a folder for source files
-		srcDir, err := os.MkdirTemp("", "funless-test-src-")
-		require.NoError(t, err)
-
-		// create n files inside the created folder
-		for i := 1; i <= numberOfFiles; i++ {
-			srcFile := fmt.Sprintf("%s/test-file-%d", srcDir, i)
-			err = os.WriteFile(srcFile, data, os.FileMode(mode))
-			require.NoError(t, err)
-		}
-
-		return srcDir, nil
-	}
-
-	fileModes := []int{0600, 0640, 0644, 0700, 0755}
-	numberOfFiles := 2
-
-	for _, mode := range fileModes {
-		// set up source with 2 files
-		srcDir, _ := createSource(t, numberOfFiles, mode)
-		defer os.RemoveAll(srcDir)
-
-		// create a destination folder to copy the files to
-		destDir, destDirErr := os.MkdirTemp("", "funless-test-dest-")
-		if destDirErr != nil {
-			t.Fatalf("Error creating destination folder\n%v", destDirErr)
-		}
-		defer os.RemoveAll(destDir)
-
-		err := copy(srcDir, destDir, "/")
-		require.NoError(t, err)
-
-		for i := 1; i <= numberOfFiles; i++ {
-			fileInfo, err := os.Stat(fmt.Sprintf("%s/test-file-%d", destDir, i))
-			require.NoError(t, err)
-			require.Equal(t, os.FileMode(mode), fileInfo.Mode())
-		}
-	}
 }

--- a/pkg/copy.go
+++ b/pkg/copy.go
@@ -1,0 +1,91 @@
+package pkg
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+)
+
+func Copy(src string, dest string) error {
+	// Get properties of source
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	// If it's a directory, create it and copy recursively
+	if info.IsDir() {
+		// 1. Create the dest directory
+		if err := os.MkdirAll(dest, info.Mode()); err != nil {
+			return fmt.Errorf("error creating: %s - %s", dest, err.Error())
+		}
+
+		// 2. Read the source directory
+		entries, err := os.ReadDir(src)
+		if err != nil {
+			// If we fail to read the source directory, remove the created directory
+			os.RemoveAll(dest)
+			return err
+		}
+
+		// 3. For each entry in the directory, recursively copy it
+		for _, dirEntry := range entries {
+			newSrc := filepath.Join(src, dirEntry.Name())
+			newDest := filepath.Join(dest, dirEntry.Name())
+			if err := Copy(newSrc, newDest); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	// If it's a file, copy it
+	return copySingleFile(src, dest)
+}
+
+func copySingleFile(src, dest string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	err = ensureBaseDir(dest)
+	if err != nil {
+		return fmt.Errorf("error creating base directory: %s", err.Error())
+	}
+
+	f, err := os.Create(dest)
+	if err != nil {
+		return fmt.Errorf("error creating dest file: %s", err.Error())
+	}
+	defer f.Close()
+
+	if err = os.Chmod(f.Name(), info.Mode()); err != nil {
+		return fmt.Errorf("error setting dest file mode: %s", err.Error())
+	}
+
+	s, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("error opening src file: %s", err.Error())
+	}
+	defer s.Close()
+
+	_, err = io.Copy(f, s)
+	if err != nil {
+		return fmt.Errorf("Error copying dest file: %s\n" + err.Error())
+	}
+
+	return nil
+}
+
+// ensureBaseDir creates the base directory of a given file path, if it does not exist.
+func ensureBaseDir(fpath string) error {
+	baseDir := path.Dir(fpath)
+	info, err := os.Stat(baseDir)
+	if err == nil && info.IsDir() {
+		return nil
+	}
+	return os.MkdirAll(baseDir, 0755)
+}

--- a/pkg/copy.go
+++ b/pkg/copy.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Giuseppe De Palma, Matteo Trentin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package pkg
 
 import (

--- a/pkg/copy_test.go
+++ b/pkg/copy_test.go
@@ -1,0 +1,55 @@
+package pkg
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Test for the copy function
+func Test_copy(t *testing.T) {
+	createSource := func(t *testing.T, numberOfFiles, mode int) (string, error) {
+		t.Helper()
+		data := []byte("a funless function")
+
+		// create a folder for source files
+		srcDir, err := os.MkdirTemp("", "funless-test-src-")
+		require.NoError(t, err)
+
+		// create n files inside the created folder
+		for i := 1; i <= numberOfFiles; i++ {
+			srcFile := fmt.Sprintf("%s/test-file-%d", srcDir, i)
+			err = os.WriteFile(srcFile, data, os.FileMode(mode))
+			require.NoError(t, err)
+		}
+
+		return srcDir, nil
+	}
+
+	fileModes := []int{0600, 0640, 0644, 0700, 0755}
+	numberOfFiles := 2
+
+	for _, mode := range fileModes {
+		// set up source with 2 files
+		srcDir, _ := createSource(t, numberOfFiles, mode)
+		defer os.RemoveAll(srcDir)
+
+		// create a destination folder to copy the files to
+		destDir, destDirErr := os.MkdirTemp("", "funless-test-dest-")
+		if destDirErr != nil {
+			t.Fatalf("Error creating destination folder\n%v", destDirErr)
+		}
+		defer os.RemoveAll(destDir)
+
+		err := Copy(srcDir, destDir)
+		require.NoError(t, err)
+
+		for i := 1; i <= numberOfFiles; i++ {
+			fileInfo, err := os.Stat(fmt.Sprintf("%s/test-file-%d", destDir, i))
+			require.NoError(t, err)
+			require.Equal(t, os.FileMode(mode), fileInfo.Mode())
+		}
+	}
+}

--- a/pkg/copy_test.go
+++ b/pkg/copy_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Giuseppe De Palma, Matteo Trentin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package pkg
 
 import (


### PR DESCRIPTION
This PR closes #81 

It adds the `fl fn new` command. Passing a name and the language chosen, the cli will attempt to read the template folder. If not found it uses the template pull cmd to pull our templates. When the templates are found it copies the template folder matching the language flag and renames the newly created folder with the given function name. 