### PR TITLE
Homedir pkg

### DIFF
--- a/pkg/homedir/home_dir.go
+++ b/pkg/homedir/home_dir.go
@@ -1,0 +1,79 @@
+// Copyright 2022 Giuseppe De Palma, Matteo Trentin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package homedir
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+var getHomeDir = os.UserHomeDir
+
+// EnsureConfigDir return the path to the config directory.
+// It creates it if needed.
+func EnsureConfigDir() (string, error) {
+	homedir, err := getHomeDir()
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(homedir, ".fl")
+	// check if the directory exists
+	_, err = os.Stat(path)
+	if os.IsNotExist(err) {
+		// if not, create the directory
+		if err := os.MkdirAll(path, 0755); err != nil {
+			return "", err
+		}
+	}
+	return path, nil
+}
+
+func WriteToConfigDir(filename string, data []byte, overwrite bool) error {
+	homedir, err := EnsureConfigDir()
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(homedir, filename)
+	if _, err := os.Stat(path); err == nil {
+		if overwrite {
+			os.Remove(path)
+		} else {
+			return errors.New("file already exists and overwrite is false")
+		}
+	}
+
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return err
+	}
+	return nil
+}
+
+func ReadFromConfigDir(filename string) ([]byte, error) {
+	homedir, err := EnsureConfigDir()
+	if err != nil {
+		return nil, err
+	}
+	path := filepath.Join(homedir, filename)
+	if _, err := os.Stat(path); err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}

--- a/pkg/homedir/home_dir.go
+++ b/pkg/homedir/home_dir.go
@@ -20,6 +20,8 @@ import (
 	"path/filepath"
 )
 
+const configDir = ".fl"
+
 var getHomeDir = os.UserHomeDir
 
 // EnsureConfigDir return the path to the config directory.
@@ -29,7 +31,7 @@ func EnsureConfigDir() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	path := filepath.Join(homedir, ".fl")
+	path := filepath.Join(homedir, configDir)
 	// check if the directory exists
 	_, err = os.Stat(path)
 	if os.IsNotExist(err) {

--- a/pkg/homedir/home_dir_test.go
+++ b/pkg/homedir/home_dir_test.go
@@ -1,0 +1,119 @@
+// Copyright 2022 Giuseppe De Palma, Matteo Trentin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package homedir
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureConfigDir(t *testing.T) {
+	homedirPath, err := os.MkdirTemp("", "funless-test-homedir-")
+	require.NoError(t, err)
+
+	getHomeDir = func() (string, error) {
+		return homedirPath, err
+	}
+	defer func() {
+		getHomeDir = os.UserHomeDir
+		os.RemoveAll(homedirPath)
+	}()
+
+	t.Run("should create the config directory if it does not exist", func(t *testing.T) {
+		path, err := EnsureConfigDir()
+		assert.NoError(t, err)
+		assert.Equal(t, filepath.Join(homedirPath, ".fl"), path)
+		_, err = os.Stat(path)
+		assert.NoError(t, err)
+	})
+
+	t.Run("should return the path to the config directory if it exists", func(t *testing.T) {
+		path, err := EnsureConfigDir()
+		assert.NoError(t, err)
+		assert.Equal(t, filepath.Join(homedirPath, ".fl"), path)
+		_, err = os.Stat(path)
+		assert.NoError(t, err)
+	})
+}
+
+func TestWriteToConfigDir(t *testing.T) {
+	homedirPath, err := os.MkdirTemp("", "funless-test-homedir-")
+	require.NoError(t, err)
+
+	getHomeDir = func() (string, error) {
+		return homedirPath, err
+	}
+	defer func() {
+		getHomeDir = os.UserHomeDir
+		os.RemoveAll(homedirPath)
+	}()
+
+	t.Run("should write the file to the config directory", func(t *testing.T) {
+		err := WriteToConfigDir("test", []byte("test"), false)
+		assert.NoError(t, err)
+		_, err = os.Stat(filepath.Join(homedirPath, ".fl", "test"))
+		assert.NoError(t, err)
+	})
+
+	t.Run("should overwrite the file if overwrite is true", func(t *testing.T) {
+		err := WriteToConfigDir("test", []byte("test"), true)
+		assert.NoError(t, err)
+		_, err = os.Stat(filepath.Join(homedirPath, ".fl", "test"))
+		assert.NoError(t, err)
+	})
+
+	t.Run("should return an error if the file already exists and overwrite is false", func(t *testing.T) {
+		err := WriteToConfigDir("test", []byte("test"), false)
+		assert.Error(t, err)
+	})
+}
+
+func TestReadFromConfigDir(t *testing.T) {
+	homedirPath, err := os.MkdirTemp("", "funless-test-homedir-")
+	require.NoError(t, err)
+
+	getHomeDir = func() (string, error) {
+		return homedirPath, err
+	}
+	defer func() {
+		getHomeDir = os.UserHomeDir
+		os.RemoveAll(homedirPath)
+	}()
+
+	t.Run("should return an error if the file does not exist", func(t *testing.T) {
+		_, err := ReadFromConfigDir("test")
+		assert.Error(t, err)
+	})
+
+	t.Run("should return the file content if the file exists", func(t *testing.T) {
+		err := WriteToConfigDir("test", []byte("test"), false)
+		assert.NoError(t, err)
+		content, err := ReadFromConfigDir("test")
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("test"), content)
+	})
+
+	t.Run("should return an error if the file is a directory", func(t *testing.T) {
+		err := os.Mkdir(filepath.Join(homedirPath, ".fl", "test-dir"), 0755)
+		assert.NoError(t, err)
+		_, err = ReadFromConfigDir("test-dir")
+		assert.Error(t, err)
+	})
+
+}


### PR DESCRIPTION
This PR closes #34 

It adds the homedir package with the EnsureConfigDir function that creates `.fl` user folder if it does not exist and the Write and Read file functions.