### PR TITLE
Fixes

### DIFF
--- a/internal/command/fn/fn.go
+++ b/internal/command/fn/fn.go
@@ -15,6 +15,7 @@
 package fn
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 
@@ -42,7 +43,11 @@ func extractError(err error) error {
 	if !castOk {
 		return err
 	}
-	if err := json.Unmarshal(openApiError.Body(), &e); err != nil {
+
+	d := json.NewDecoder(bytes.NewReader(openApiError.Body()))
+	d.DisallowUnknownFields()
+
+	if err := d.Decode(&e); err != nil {
 		return err
 	}
 	return errors.New(e.Errors.Detail)

--- a/internal/command/mod/create.go
+++ b/internal/command/mod/create.go
@@ -29,7 +29,7 @@ func (c *Create) Run(ctx context.Context, modHandler client.ModHandler, logger l
 	err := modHandler.Create(ctx, c.Name)
 
 	if err != nil {
-		return err
+		return extractError(err)
 	}
 
 	logger.Infof("Successfully created module %s.\n", c.Name)

--- a/internal/command/mod/delete.go
+++ b/internal/command/mod/delete.go
@@ -29,7 +29,7 @@ func (d *Delete) Run(ctx context.Context, modHandler client.ModHandler, logger l
 	err := modHandler.Delete(ctx, d.Name)
 
 	if err != nil {
-		return err
+		return extractError(err)
 	}
 
 	logger.Infof("Successfully deleted module %s.\n", d.Name)

--- a/internal/command/mod/get.go
+++ b/internal/command/mod/get.go
@@ -37,7 +37,7 @@ func (g *Get) Run(ctx context.Context, modHandler client.ModHandler, logger log.
 	functions := data.Functions
 
 	if err != nil {
-		return err
+		return extractError(err)
 	}
 	logger.Infof("Module: %s\n", *name)
 	logger.Info("Functions:")

--- a/internal/command/mod/mod.go
+++ b/internal/command/mod/mod.go
@@ -15,6 +15,7 @@
 package mod
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 
@@ -42,7 +43,11 @@ func extractError(err error) error {
 	if !castOk {
 		return err
 	}
-	if err := json.Unmarshal(openApiError.Body(), &e); err != nil {
+
+	d := json.NewDecoder(bytes.NewReader(openApiError.Body()))
+	d.DisallowUnknownFields()
+
+	if err := d.Decode(&e); err != nil {
 		return err
 	}
 	return errors.New(e.Errors.Detail)

--- a/internal/command/mod/update.go
+++ b/internal/command/mod/update.go
@@ -30,7 +30,7 @@ func (u *Update) Run(ctx context.Context, modHandler client.ModHandler, logger l
 	err := modHandler.Update(ctx, u.Name, u.NewName)
 
 	if err != nil {
-		return err
+		return extractError(err)
 	}
 
 	logger.Infof("Successfully renamed module %s to %s.\n", u.Name, u.NewName)

--- a/pkg/build/wasm.go
+++ b/pkg/build/wasm.go
@@ -17,8 +17,10 @@ package build
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
@@ -61,11 +63,11 @@ func (b *WasmBuilder) Setup(flDocker docker.DockerClient, language string, dest 
 	}
 	b.builderImg = lang.BuilderImage
 
-	containerName, exists := builderNames[language]
+	containerBaseName, exists := builderNames[language]
 	if !exists {
 		return errors.New("no corresponding builder name found for the given language")
 	}
-	b.builderContainerName = containerName
+	b.builderContainerName = containerBaseName + fmt.Sprintf("%d", time.Now().UnixMilli())
 	b.flDocker = flDocker
 	b.outPath = dest
 


### PR DESCRIPTION
This PR handles two issues currently affecting the CLI.

Specifically:

- Closes #107, adding the current epoch timestamp to the builder container name
- Closes #106, adding the missing `ExtractError` calls

Regarding #106, the generic errors are caused by the backend (the actual text is just `404 Not Found`); the empty errors are caused by unknown keys being passed in the error body. A custom JSON decoder is now used in `ExtractError`, to communicate when an unknown key was found in the API error body.