### PR TITLE
Namespace module refactor

### DIFF
--- a/internal/command/fn/create.go
+++ b/internal/command/fn/create.go
@@ -26,10 +26,10 @@ import (
 )
 
 type Create struct {
-	Name      string `arg:"" help:"name of the function to create"`
-	Source    string `arg:"" type:"existingdir" help:"path of the source directory"`
-	Namespace string `short:"n" default:"_" help:"namespace of the function to create"`
-	Language  string `short:"l" required:"" enum:"rust,js" help:"programming language of the function"`
+	Name     string `arg:"" help:"name of the function to create"`
+	Source   string `arg:"" type:"existingdir" help:"path of the source directory"`
+	Module   string `short:"m" default:"_" help:"module of the function to create"`
+	Language string `short:"l" required:"" enum:"rust,js" help:"programming language of the function"`
 }
 
 func (c *Create) Run(ctx context.Context, builder build.DockerBuilder, fnHandler client.FnHandler, logger log.FLogger) error {
@@ -62,12 +62,12 @@ func (c *Create) Run(ctx context.Context, builder build.DockerBuilder, fnHandler
 		return logger.StopSpinner(err)
 	}
 
-	err = fnHandler.Create(ctx, c.Name, c.Namespace, code)
+	err = fnHandler.Create(ctx, c.Name, c.Module, code)
 	if err != nil {
 		return logger.StopSpinner(extractError(err))
 	}
 	_ = logger.StopSpinner(nil)
 
-	logger.Info(fmt.Sprintf("\nSuccessfully created function %s/%s.\n", c.Namespace, c.Name))
+	logger.Info(fmt.Sprintf("\nSuccessfully created function %s/%s.\n", c.Module, c.Name))
 	return nil
 }

--- a/internal/command/fn/create_test.go
+++ b/internal/command/fn/create_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -30,24 +31,34 @@ import (
 )
 
 func TestFnCreate(t *testing.T) {
-	testResult := `Creating test-fn function...
+	// 	testResult := `Creating test-fn function...
+
+	// Building function...🏗 ️
+	// done
+	// Uploading function... 📮
+	// done
+
+	// Successfully created function test-mod/test-fn.
+	// `
+	testFn := "test-fn"
+	testMod := "test-mod"
+	testResult := fmt.Sprintf(`Creating test-fn function...
 
 Building function...🏗 ️
 done
 Uploading function... 📮
 done
 
-Successfully created function test-ns/test-fn.
-`
-	testFn := "test-fn"
-	testNs := "test-ns"
+Successfully created function %s/%s.
+`,
+		testMod, testFn)
 	testLanguage := "js"
 	testDir, _ := filepath.Abs("../../../test/fixtures/test_dir/")
 	ctx := context.Background()
 	testLogger, _ := log.NewLoggerBuilder().WithWriter(os.Stdout).DisableAnimation().Build()
 
 	mockFnHandler := mocks.NewFnHandler(t)
-	mockFnHandler.On("Create", ctx, testFn, testNs, mock.Anything).Return(nil)
+	mockFnHandler.On("Create", ctx, testFn, testMod, mock.Anything).Return(nil)
 
 	mockBuilder := mocks.NewDockerBuilder(t)
 	mockBuilder.On("Setup", mock.Anything, testLanguage, mock.Anything).Return(nil)
@@ -61,10 +72,10 @@ Successfully created function test-ns/test-fn.
 
 	t.Run("success: should correctly print result when building from a directory", func(t *testing.T) {
 		cmd := Create{
-			Name:      testFn,
-			Namespace: testNs,
-			Source:    testDir,
-			Language:  testLanguage,
+			Name:     testFn,
+			Module:   testMod,
+			Source:   testDir,
+			Language: testLanguage,
 		}
 
 		var outbuf bytes.Buffer
@@ -75,7 +86,7 @@ Successfully created function test-ns/test-fn.
 
 		require.NoError(t, err)
 		assert.Equal(t, testResult, (&outbuf).String())
-		mockFnHandler.AssertCalled(t, "Create", ctx, testFn, testNs, mock.AnythingOfType("*os.File"))
+		mockFnHandler.AssertCalled(t, "Create", ctx, testFn, testMod, mock.AnythingOfType("*os.File"))
 		mockFnHandler.AssertNumberOfCalls(t, "Create", 1)
 		mockFnHandler.AssertExpectations(t)
 		mockBuilder.AssertExpectations(t)
@@ -83,10 +94,10 @@ Successfully created function test-ns/test-fn.
 
 	t.Run("should use DockerBuilder.BuildSource to build functions", func(t *testing.T) {
 		cmd := Create{
-			Name:      testFn,
-			Namespace: testNs,
-			Source:    testDir,
-			Language:  testLanguage,
+			Name:     testFn,
+			Module:   testMod,
+			Source:   testDir,
+			Language: testLanguage,
 		}
 
 		err := cmd.Run(ctx, mockBuilder, mockFnHandler, testLogger)
@@ -99,10 +110,10 @@ Successfully created function test-ns/test-fn.
 
 	t.Run("should return error if builder setup encounters errors", func(t *testing.T) {
 		cmd := Create{
-			Name:      testFn,
-			Namespace: testNs,
-			Source:    testDir,
-			Language:  testLanguage,
+			Name:     testFn,
+			Module:   testMod,
+			Source:   testDir,
+			Language: testLanguage,
 		}
 
 		mockBuilder := mocks.NewDockerBuilder(t)
@@ -115,10 +126,10 @@ Successfully created function test-ns/test-fn.
 
 	t.Run("should return error if builder image cannot be pulled", func(t *testing.T) {
 		cmd := Create{
-			Name:      testFn,
-			Namespace: testNs,
-			Source:    testDir,
-			Language:  testLanguage,
+			Name:     testFn,
+			Module:   testMod,
+			Source:   testDir,
+			Language: testLanguage,
 		}
 
 		mockBuilder := mocks.NewDockerBuilder(t)
@@ -132,10 +143,10 @@ Successfully created function test-ns/test-fn.
 
 	t.Run("should return error if builder image encounters errors", func(t *testing.T) {
 		cmd := Create{
-			Name:      testFn,
-			Namespace: testNs,
-			Source:    testDir,
-			Language:  testLanguage,
+			Name:     testFn,
+			Module:   testMod,
+			Source:   testDir,
+			Language: testLanguage,
 		}
 
 		mockBuilder := mocks.NewDockerBuilder(t)

--- a/internal/command/fn/create_test.go
+++ b/internal/command/fn/create_test.go
@@ -31,15 +31,6 @@ import (
 )
 
 func TestFnCreate(t *testing.T) {
-	// 	testResult := `Creating test-fn function...
-
-	// Building function...🏗 ️
-	// done
-	// Uploading function... 📮
-	// done
-
-	// Successfully created function test-mod/test-fn.
-	// `
 	testFn := "test-fn"
 	testMod := "test-mod"
 	testResult := fmt.Sprintf(`Creating test-fn function...

--- a/internal/command/fn/delete.go
+++ b/internal/command/fn/delete.go
@@ -22,16 +22,16 @@ import (
 )
 
 type Delete struct {
-	Name      string `arg:"" name:"name" help:"name of the function to delete"`
-	Namespace string `name:"namespace" short:"n" default:"_" help:"namespace of the function to delete"`
+	Name   string `arg:"" name:"name" help:"name of the function to delete"`
+	Module string `name:"module" short:"m" default:"_" help:"module of the function to delete"`
 }
 
 func (f *Delete) Run(ctx context.Context, fnHandler client.FnHandler, logger log.FLogger) error {
-	err := fnHandler.Delete(ctx, f.Name, f.Namespace)
+	err := fnHandler.Delete(ctx, f.Name, f.Module)
 	if err != nil {
 		return extractError(err)
 	}
 
-	logger.Infof("\nSuccessfully deleted function %s/%s.\n", f.Namespace, f.Name)
+	logger.Infof("\nSuccessfully deleted function %s/%s.\n", f.Module, f.Name)
 	return nil
 }

--- a/internal/command/fn/delete_test.go
+++ b/internal/command/fn/delete_test.go
@@ -31,33 +31,33 @@ import (
 
 func TestFnDelete(t *testing.T) {
 	testFn := "test-fn"
-	testNs := "test-ns"
+	testMod := "test-mod"
 	testCtx := context.Background()
 	testLogger, _ := log.NewLoggerBuilder().WithWriter(os.Stdout).Build()
 
 	t.Run("should use FnService.Delete to delete functions", func(t *testing.T) {
 		cmd := Delete{
-			Name:      testFn,
-			Namespace: testNs,
+			Name:   testFn,
+			Module: testMod,
 		}
 
 		mockFnHandler := mocks.NewFnHandler(t)
-		mockFnHandler.On("Delete", testCtx, testFn, testNs).Return(nil)
+		mockFnHandler.On("Delete", testCtx, testFn, testMod).Return(nil)
 
 		err := cmd.Run(testCtx, mockFnHandler, testLogger)
 		require.NoError(t, err)
-		mockFnHandler.AssertCalled(t, "Delete", testCtx, testFn, testNs)
+		mockFnHandler.AssertCalled(t, "Delete", testCtx, testFn, testMod)
 		mockFnHandler.AssertNumberOfCalls(t, "Delete", 1)
 		mockFnHandler.AssertExpectations(t)
 	})
 	t.Run("should correctly print result", func(t *testing.T) {
 		cmd := Delete{
-			Name:      testFn,
-			Namespace: testNs,
+			Name:   testFn,
+			Module: testMod,
 		}
 
 		mockFnHandler := mocks.NewFnHandler(t)
-		mockFnHandler.On("Delete", testCtx, testFn, testNs).Return(nil)
+		mockFnHandler.On("Delete", testCtx, testFn, testMod).Return(nil)
 
 		var outbuf bytes.Buffer
 		bufLogger, _ := log.NewLoggerBuilder().WithWriter(&outbuf).Build()
@@ -65,20 +65,20 @@ func TestFnDelete(t *testing.T) {
 		err := cmd.Run(testCtx, mockFnHandler, bufLogger)
 
 		require.NoError(t, err)
-		assert.Equal(t, fmt.Sprintf("\nSuccessfully deleted function %s/%s.\n", testNs, testFn), (&outbuf).String())
+		assert.Equal(t, fmt.Sprintf("\nSuccessfully deleted function %s/%s.\n", testMod, testFn), (&outbuf).String())
 		mockFnHandler.AssertExpectations(t)
 	})
 
 	t.Run("should return error if invalid delete request", func(t *testing.T) {
 		cmd := Delete{
-			Name:      testFn,
-			Namespace: testNs,
+			Name:   testFn,
+			Module: testMod,
 		}
 
 		mockFnHandler := mocks.NewFnHandler(t)
 
 		e := &openapi.GenericOpenAPIError{}
-		mockFnHandler.On("Delete", testCtx, testFn, testNs).Return(e)
+		mockFnHandler.On("Delete", testCtx, testFn, testMod).Return(e)
 
 		err := cmd.Run(testCtx, mockFnHandler, testLogger)
 		require.Error(t, err)

--- a/internal/command/fn/invoke.go
+++ b/internal/command/fn/invoke.go
@@ -24,10 +24,10 @@ import (
 )
 
 type Invoke struct {
-	Name      string            `arg:"" name:"name" help:"name of the function to invoke"`
-	Namespace string            `name:"namespace" short:"n" default:"_" help:"namespace of the function to invoke"`
-	Args      map[string]string `name:"args" short:"a" help:"arguments of the function to invoke" xor:"args"`
-	JsonArgs  string            `name:"json" short:"j" help:"json encoded arguments of the function to invoke; overrides args" xor:"args"`
+	Name     string            `arg:"" name:"name" help:"name of the function to invoke"`
+	Module   string            `name:"module" short:"n" default:"_" help:"module of the function to invoke"`
+	Args     map[string]string `name:"args" short:"a" help:"arguments of the function to invoke" xor:"args"`
+	JsonArgs string            `name:"json" short:"j" help:"json encoded arguments of the function to invoke; overrides args" xor:"args"`
 }
 
 func (f *Invoke) Run(ctx context.Context, fnHandler client.FnHandler, logger log.FLogger) error {
@@ -42,7 +42,7 @@ func (f *Invoke) Run(ctx context.Context, fnHandler client.FnHandler, logger log
 			return err
 		}
 	}
-	res, err := fnHandler.Invoke(ctx, f.Name, f.Namespace, args)
+	res, err := fnHandler.Invoke(ctx, f.Name, f.Module, args)
 	if err != nil {
 		return extractError(err)
 	}

--- a/internal/command/fn/invoke_test.go
+++ b/internal/command/fn/invoke_test.go
@@ -32,7 +32,7 @@ import (
 func TestFnInvoke(t *testing.T) {
 	testResult := map[string]interface{}{"payload": "Hi"}
 	testFn := "test-fn"
-	testNs := "test-ns"
+	testMod := "test-mod"
 	testArgs := map[string]string{"name": "Some name"}
 	testJArgs := "{\"name\":\"Some name\"}"
 	testParsedJArgs := map[string]interface{}{"name": "Some name"}
@@ -41,30 +41,30 @@ func TestFnInvoke(t *testing.T) {
 
 	t.Run("should use FnService.Invoke to invoke functions", func(t *testing.T) {
 		cmd := Invoke{
-			Name:      testFn,
-			Namespace: testNs,
-			Args:      map[string]string{},
+			Name:   testFn,
+			Module: testMod,
+			Args:   map[string]string{},
 		}
 
 		mockFnHandler := mocks.NewFnHandler(t)
-		mockFnHandler.On("Invoke", testCtx, testFn, testNs, map[string]interface{}{}).Return(openapi.InvokeResult{Data: testResult}, nil)
+		mockFnHandler.On("Invoke", testCtx, testFn, testMod, map[string]interface{}{}).Return(openapi.InvokeResult{Data: testResult}, nil)
 
 		err := cmd.Run(testCtx, mockFnHandler, testLogger)
 		require.NoError(t, err)
-		mockFnHandler.AssertCalled(t, "Invoke", testCtx, testFn, testNs, map[string]interface{}{})
+		mockFnHandler.AssertCalled(t, "Invoke", testCtx, testFn, testMod, map[string]interface{}{})
 		mockFnHandler.AssertNumberOfCalls(t, "Invoke", 1)
 		mockFnHandler.AssertExpectations(t)
 	})
 
 	t.Run("should correctly print result", func(t *testing.T) {
 		cmd := Invoke{
-			Name:      testFn,
-			Namespace: testNs,
-			Args:      map[string]string{},
+			Name:   testFn,
+			Module: testMod,
+			Args:   map[string]string{},
 		}
 
 		mockFnHandler := mocks.NewFnHandler(t)
-		mockFnHandler.On("Invoke", testCtx, testFn, testNs, map[string]interface{}{}).Return(openapi.InvokeResult{Data: testResult}, nil)
+		mockFnHandler.On("Invoke", testCtx, testFn, testMod, map[string]interface{}{}).Return(openapi.InvokeResult{Data: testResult}, nil)
 
 		var outbuf bytes.Buffer
 		var testOutput, _ = json.Marshal(testResult)
@@ -79,9 +79,9 @@ func TestFnInvoke(t *testing.T) {
 
 	t.Run("should correctly parse and forward keyword args", func(t *testing.T) {
 		cmd := Invoke{
-			Name:      testFn,
-			Namespace: testNs,
-			Args:      testArgs,
+			Name:   testFn,
+			Module: testMod,
+			Args:   testArgs,
 		}
 
 		mockArgs := make(map[string]interface{}, len(testArgs))
@@ -90,28 +90,28 @@ func TestFnInvoke(t *testing.T) {
 		}
 
 		mockFnHandler := mocks.NewFnHandler(t)
-		mockFnHandler.On("Invoke", testCtx, testFn, testNs, mockArgs).Return(openapi.InvokeResult{Data: testResult}, nil)
+		mockFnHandler.On("Invoke", testCtx, testFn, testMod, mockArgs).Return(openapi.InvokeResult{Data: testResult}, nil)
 
 		err := cmd.Run(testCtx, mockFnHandler, testLogger)
 		require.NoError(t, err)
-		mockFnHandler.AssertCalled(t, "Invoke", testCtx, testFn, testNs, mockArgs)
+		mockFnHandler.AssertCalled(t, "Invoke", testCtx, testFn, testMod, mockArgs)
 		mockFnHandler.AssertNumberOfCalls(t, "Invoke", 1)
 		mockFnHandler.AssertExpectations(t)
 	})
 
 	t.Run("should correctly parse and forward json args", func(t *testing.T) {
 		cmd := Invoke{
-			Name:      testFn,
-			Namespace: testNs,
-			JsonArgs:  testJArgs,
+			Name:     testFn,
+			Module:   testMod,
+			JsonArgs: testJArgs,
 		}
 
 		mockFnHandler := mocks.NewFnHandler(t)
-		mockFnHandler.On("Invoke", testCtx, testFn, testNs, testParsedJArgs).Return(openapi.InvokeResult{Data: testResult}, nil)
+		mockFnHandler.On("Invoke", testCtx, testFn, testMod, testParsedJArgs).Return(openapi.InvokeResult{Data: testResult}, nil)
 
 		err := cmd.Run(testCtx, mockFnHandler, testLogger)
 		require.NoError(t, err)
-		mockFnHandler.AssertCalled(t, "Invoke", testCtx, testFn, testNs, testParsedJArgs)
+		mockFnHandler.AssertCalled(t, "Invoke", testCtx, testFn, testMod, testParsedJArgs)
 		mockFnHandler.AssertNumberOfCalls(t, "Invoke", 1)
 		mockFnHandler.AssertExpectations(t)
 	})

--- a/internal/command/fn/upload.go
+++ b/internal/command/fn/upload.go
@@ -29,9 +29,9 @@ import (
 )
 
 type Upload struct {
-	Name      string `arg:"" help:"the name of the function"`
-	Source    string `arg:"" type:"existingfile" help:"path of the wasm binary"`
-	Namespace string `short:"n" default:"_" help:"the namespace of the function"`
+	Name   string `arg:"" help:"the name of the function"`
+	Source string `arg:"" type:"existingfile" help:"path of the wasm binary"`
+	Module string `short:"m" default:"_" help:"the module of the function"`
 }
 
 func (u *Upload) Run(ctx context.Context, fnHandler client.FnHandler, logger log.FLogger) error {
@@ -43,13 +43,13 @@ func (u *Upload) Run(ctx context.Context, fnHandler client.FnHandler, logger log
 	_ = logger.StopSpinner(nil)
 
 	_ = logger.StartSpinner("Uploading function...")
-	err = fnHandler.Create(ctx, u.Name, u.Namespace, code)
+	err = fnHandler.Create(ctx, u.Name, u.Module, code)
 	if err != nil {
 		return logger.StopSpinner(extractError(err))
 	}
 	_ = logger.StopSpinner(nil)
 
-	logger.Info(fmt.Sprintf("Successfully uploaded function %s/%s 👌\n", u.Namespace, u.Name))
+	logger.Info(fmt.Sprintf("Successfully uploaded function %s/%s 👌\n", u.Module, u.Name))
 	return nil
 }
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	DefaultNamespace = "_"
+	DefaultModule = "_"
 )
 
 type Client struct {

--- a/pkg/client/fn_service_test.go
+++ b/pkg/client/fn_service_test.go
@@ -33,18 +33,18 @@ import (
 
 func TestFnInvoke(t *testing.T) {
 	testFn := "test_fn"
-	testNs := "test_ns"
+	testMod := "test_mod"
 	var testArgs map[string]interface{} = map[string]interface{}{"name": "Some name"}
 
 	testCtx := context.Background()
 	mockValidator := mocks.NewInputValidatorHandler(t)
 	mockValidator.On("ValidateName", testFn, "function").Return(nil)
-	mockValidator.On("ValidateName", testNs, "mod").Return(nil)
+	mockValidator.On("ValidateName", testMod, "mod").Return(nil)
 
 	t.Run("should send invoke request to server", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPost, r.Method)
-			assert.Equal(t, fmt.Sprintf("/v1/fn/%s/%s", testNs, testFn), r.URL.Path)
+			assert.Equal(t, fmt.Sprintf("/v1/fn/%s/%s", testMod, testFn), r.URL.Path)
 			w.Header().Set("Content-Type", "application/json")
 			result := map[string]map[string]string{"Data": {"payload": "some result"}}
 			jresult, _ := json.Marshal(result)
@@ -55,7 +55,7 @@ func TestFnInvoke(t *testing.T) {
 		c, _ := NewClient(http.DefaultClient, Config{Host: server.URL})
 		svc := &FnService{Client: c, InputValidatorHandler: mockValidator}
 
-		result, err := svc.Invoke(testCtx, testFn, testNs, testArgs)
+		result, err := svc.Invoke(testCtx, testFn, testMod, testArgs)
 
 		require.NoError(t, err)
 		expected := map[string]interface{}{"payload": "some result"}
@@ -68,7 +68,7 @@ func TestFnInvoke(t *testing.T) {
 	t.Run("should return error if request encounters an HTTP error", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPost, r.Method)
-			assert.Equal(t, fmt.Sprintf("/v1/fn/%s/%s", testNs, testFn), r.URL.Path)
+			assert.Equal(t, fmt.Sprintf("/v1/fn/%s/%s", testMod, testFn), r.URL.Path)
 			w.Header().Set("Content-Type", "application/json")
 			result := map[string]string{"error": "some error"}
 			jresult, _ := json.Marshal(result)
@@ -81,7 +81,7 @@ func TestFnInvoke(t *testing.T) {
 		c, _ := NewClient(http.DefaultClient, Config{Host: server.URL})
 		svc := &FnService{Client: c, InputValidatorHandler: mockValidator}
 
-		_, err := svc.Invoke(testCtx, testFn, testNs, testArgs)
+		_, err := svc.Invoke(testCtx, testFn, testMod, testArgs)
 
 		require.Error(t, err)
 		openApiError := err.(*openapi.GenericOpenAPIError)
@@ -91,7 +91,7 @@ func TestFnInvoke(t *testing.T) {
 
 func TestFnCreate(t *testing.T) {
 	testFn := "test_fn"
-	testNs := "test_ns"
+	testMod := "test_mod"
 	testSource, _ := filepath.Abs("../../test/fixtures/real.wasm")
 	testCode, _ := os.Open(testSource)
 
@@ -99,12 +99,12 @@ func TestFnCreate(t *testing.T) {
 
 	mockValidator := mocks.NewInputValidatorHandler(t)
 	mockValidator.On("ValidateName", testFn, "function").Return(nil)
-	mockValidator.On("ValidateName", testNs, "mod").Return(nil)
+	mockValidator.On("ValidateName", testMod, "mod").Return(nil)
 
 	t.Run("should send create request to server", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPost, r.Method)
-			assert.Equal(t, fmt.Sprintf("/v1/fn/%s", testNs), r.URL.Path)
+			assert.Equal(t, fmt.Sprintf("/v1/fn/%s", testMod), r.URL.Path)
 			w.Header().Set("Content-Type", "application/json")
 			result := map[string]string{"Result": "some result"}
 			jresult, _ := json.Marshal(result)
@@ -115,7 +115,7 @@ func TestFnCreate(t *testing.T) {
 		c, _ := NewClient(http.DefaultClient, Config{Host: server.URL})
 		svc := &FnService{Client: c, InputValidatorHandler: mockValidator}
 
-		err := svc.Create(testCtx, testFn, testNs, testCode)
+		err := svc.Create(testCtx, testFn, testMod, testCode)
 
 		require.NoError(t, err)
 
@@ -126,7 +126,7 @@ func TestFnCreate(t *testing.T) {
 	t.Run("should return error if request encounters an HTTP error", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPost, r.Method)
-			assert.Equal(t, fmt.Sprintf("/v1/fn/%s", testNs), r.URL.Path)
+			assert.Equal(t, fmt.Sprintf("/v1/fn/%s", testMod), r.URL.Path)
 			w.Header().Set("Content-Type", "application/json")
 			result := map[string]string{"error": "some error"}
 			jresult, _ := json.Marshal(result)
@@ -139,7 +139,7 @@ func TestFnCreate(t *testing.T) {
 		c, _ := NewClient(http.DefaultClient, Config{Host: server.URL})
 		svc := &FnService{Client: c, InputValidatorHandler: mockValidator}
 
-		err := svc.Create(testCtx, testFn, testNs, testCode)
+		err := svc.Create(testCtx, testFn, testMod, testCode)
 
 		require.Error(t, err)
 		openApiError := err.(*openapi.GenericOpenAPIError)
@@ -149,18 +149,18 @@ func TestFnCreate(t *testing.T) {
 
 func TestFnDelete(t *testing.T) {
 	testFn := "test_fn"
-	testNs := "test_ns"
+	testMod := "test_mod"
 
 	testCtx := context.Background()
 
 	mockValidator := mocks.NewInputValidatorHandler(t)
 	mockValidator.On("ValidateName", testFn, "function").Return(nil)
-	mockValidator.On("ValidateName", testNs, "mod").Return(nil)
+	mockValidator.On("ValidateName", testMod, "mod").Return(nil)
 
 	t.Run("should send delete request to server", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodDelete, r.Method)
-			assert.Equal(t, fmt.Sprintf("/v1/fn/%s/%s", testNs, testFn), r.URL.Path)
+			assert.Equal(t, fmt.Sprintf("/v1/fn/%s/%s", testMod, testFn), r.URL.Path)
 			w.Header().Set("Content-Type", "application/json")
 			result := map[string]string{"Result": "some result"}
 			jresult, _ := json.Marshal(result)
@@ -171,7 +171,7 @@ func TestFnDelete(t *testing.T) {
 		c, _ := NewClient(http.DefaultClient, Config{Host: server.URL})
 		svc := &FnService{Client: c, InputValidatorHandler: mockValidator}
 
-		err := svc.Delete(testCtx, testFn, testNs)
+		err := svc.Delete(testCtx, testFn, testMod)
 
 		require.NoError(t, err)
 
@@ -182,7 +182,7 @@ func TestFnDelete(t *testing.T) {
 	t.Run("should return error if request encounters an HTTP error", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodDelete, r.Method)
-			assert.Equal(t, fmt.Sprintf("/v1/fn/%s/%s", testNs, testFn), r.URL.Path)
+			assert.Equal(t, fmt.Sprintf("/v1/fn/%s/%s", testMod, testFn), r.URL.Path)
 			w.Header().Set("Content-Type", "application/json")
 			result := map[string]string{"error": "some error"}
 			jresult, _ := json.Marshal(result)
@@ -195,7 +195,7 @@ func TestFnDelete(t *testing.T) {
 		c, _ := NewClient(http.DefaultClient, Config{Host: server.URL})
 		svc := &FnService{Client: c, InputValidatorHandler: mockValidator}
 
-		err := svc.Delete(testCtx, testFn, testNs)
+		err := svc.Delete(testCtx, testFn, testMod)
 
 		require.Error(t, err)
 		openApiError := err.(*openapi.GenericOpenAPIError)


### PR DESCRIPTION
This PR closes #105 

Additionally, it replaces hard-coded testResult strings in `create_test.go` and `upload_test.go` with `fmt.Sprintf`.